### PR TITLE
Add Sentry reporting

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,15 +4,21 @@ import 'package:reaxit/providers/pizzas_provider.dart';
 import 'package:reaxit/providers/notifications_provider.dart';
 import 'package:reaxit/providers/theme_mode_provider.dart';
 import 'package:reaxit/ui/styles/theme.dart';
-
 import 'package:provider/provider.dart';
 import 'package:reaxit/providers/auth_provider.dart';
 import 'package:reaxit/providers/events_provider.dart';
 import 'package:reaxit/providers/members_provider.dart';
 import 'package:reaxit/providers/photos_provider.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
 
-void main() {
-  runApp(ThaliApp());
+Future<void> main() async {
+  await SentryFlutter.init(
+    (options) {
+      options.dsn = "https://ddc09a4019314587a8bda17"
+          "3ff3ee038@o263149.ingest.sentry.io/5652574";
+    },
+    appRunner: () => runApp(ThaliApp()),
+  );
 }
 
 class ThaliApp extends StatelessWidget {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -415,6 +415,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.3"
+  package_info:
+    dependency: transitive
+    description:
+      name: package_info
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.3+4"
   path:
     dependency: transitive
     description:
@@ -555,6 +562,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  sentry:
+    dependency: transitive
+    description:
+      name: sentry
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.6"
+  sentry_flutter:
+    dependency: "direct main"
+    description:
+      name: sentry_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.6"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -728,6 +749,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.2"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,9 @@ dependencies:
   # persistent storage 
   shared_preferences: ^2.0.3
 
+  # sentry error reporting
+  sentry_flutter: ^4.0.6
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
Closes #30 

Add basic Sentry reporting. When #33 is done, or when we do #32, we should probably set the sentry DSN through environment variables. I think Fastlane should also set version info.
