### PR TITLE
Fix profile achievements showing wrong dates

### DIFF
--- a/lib/ui/screens/profile_screen.dart
+++ b/lib/ui/screens/profile_screen.dart
@@ -447,7 +447,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
         children: achievement.periods!.map((Period period) {
           final since = dateFormatter.format(period.since);
           final until = (period.until != null)
-              ? dateFormatter.format(period.since)
+              ? dateFormatter.format(period.until!)
               : 'Present';
           final dates = '$since - $until';
           var leading = '';


### PR DESCRIPTION
The profiles used to show the 'since' date twice, instead of '<since> - <until>'. That's been fixed.
