### PR TITLE
Add space after "you are registered" message on events for which no r…

### DIFF
--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -398,7 +398,7 @@ class _EventScreenState extends State<EventScreen> {
     Widget registrationButton = const SizedBox.shrink();
 
     if (event.isInvited) {
-      textSpans.add(const TextSpan(text: 'You are registered.'));
+      textSpans.add(const TextSpan(text: 'You are registered. '));
       if (event.canCancelRegistration) {
         registrationButton = _makeIWontBeThereButton(event);
       }


### PR DESCRIPTION
…egistration is required



<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating a tool, changing the CI settings etc; no production code change

-->

### Summary
Now there's a space between "You are registered.No registration required."

### How to test
Steps to test the changes you made:
1. Go to an event for which no registration is required. (Borrel with ICIS or Long current event on staging will work)
2. Register.
3. There's a space between the two sentences.
