### PR TITLE
Fixed incorrect path to default default-avatar.jpg

### DIFF
--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -873,7 +873,7 @@ class _EventScreenState extends State<EventScreen> {
                   child: Stack(
                     fit: StackFit.expand,
                     children: [
-                      Image.asset('assets/image/default-avatar.jpg'),
+                      Image.asset('assets/img/default-avatar.jpg'),
                       Container(
                         padding: const EdgeInsets.all(8),
                         alignment: Alignment.bottomLeft,


### PR DESCRIPTION
### Summary
Fixed a crash caused by an incorrect path for registered members that do not have a avatar.

### How to test
Steps to test the changes you made:
1. Go to 'LONG CURRENT EVENT'
2. Scroll down to 'Cool Member 1' and 'Cool Member 2'
