### PR TITLE
Change map links to deeplinks

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -34,6 +34,10 @@
 				</array>
 			</dict>
 		</array>
+		<key>LSApplicationQueriesSchemes</key>
+		<array>
+			<string>maps</string>
+		</array>
 		<key>CFBundleVersion</key>
 		<string>$(FLUTTER_BUILD_NUMBER)</string>
 		<key>FlutterDeepLinkingEnabled</key>

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -59,9 +59,9 @@ class _EventScreenState extends State<EventScreen> {
           ? Uri(scheme: 'maps', queryParameters: {'daddr': event.location})
           : Uri(
               scheme: 'https',
-              host: 'www.google.com',
-              path: 'maps/search',
-              queryParameters: {'api': 1, 'query': event.location},
+              host: 'maps.google.com',
+              path: 'maps',
+              queryParameters: {'daddr': event.location},
             ),
       builder: (context, followLink) => GestureDetector(
         onTap: followLink,

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -55,12 +55,14 @@ class _EventScreenState extends State<EventScreen> {
 
   Widget _makeMap(Event event) {
     return Link(
-      uri: Uri(
-        scheme: Theme.of(context).platform == TargetPlatform.iOS
-            ? 'maps'
-            : 'comgooglemaps',
-        queryParameters: {'daddr': event.location},
-      ),
+      uri: Theme.of(context).platform == TargetPlatform.iOS
+          ? Uri(scheme: 'maps', queryParameters: {'daddr': event.location})
+          : Uri(
+              scheme: 'https',
+              host: 'www.google.com',
+              path: 'maps/search',
+              queryParameters: {'api': 1, 'query': event.location},
+            ),
       builder: (context, followLink) => GestureDetector(
         onTap: followLink,
         child: FadeInImage.assetNetwork(

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -77,14 +77,6 @@ class _EventScreenState extends State<EventScreen> {
               path: 'maps',
               queryParameters: {'daddr': event.location},
             ),
-      uri: Theme.of(context).platform == TargetPlatform.iOS
-          ? Uri(scheme: 'maps', queryParameters: {'daddr': event.location})
-          : Uri(
-              scheme: 'https',
-              host: 'maps.google.com',
-              path: 'maps',
-              queryParameters: {'daddr': event.location},
-            ),
       builder: (context, followLink) => Stack(
         fit: StackFit.loose,
         children: [

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -55,9 +55,11 @@ class _EventScreenState extends State<EventScreen> {
 
   Widget _makeMap(Event event) {
     return Link(
-      uri: Uri.parse(
-        'https://maps.${Theme.of(context).platform == TargetPlatform.iOS ? 'apple' : 'google'}.com'
-        '/maps?daddr=${Uri.encodeComponent(event.location)}',
+      uri: Uri(
+        scheme: Theme.of(context).platform == TargetPlatform.iOS
+            ? 'maps'
+            : 'comgooglemaps',
+        queryParameters: {'daddr': event.location},
       ),
       builder: (context, followLink) => GestureDetector(
         onTap: followLink,


### PR DESCRIPTION
This opens maps directly on  iOS, instead of via the browser.

### How to test

I've not tested on android, since for some reason my emulator died. Is it okay to assume the comgooglemaps url scheme to be available? If not, it should also be possible to fall back to an https url.