### PR TITLE
Move About card to bottom

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,7 +122,7 @@ class _ThaliAppState extends State<ThaliApp> {
                         authState.apiRepository,
                         _firebaseInitialization,
                       )..load(),
-                      lazy: true,
+                      lazy: false,
                     ),
                   ],
                   child: MaterialApp.router(


### PR DESCRIPTION
Closes #151.

### Summary 

Moves the About card in settings down to the bottom.
This makes the SettingsCubit not lazy, so that notifications will practically always be loaded before showing the setting screen, removing a flashy change when it's finished loading. 
