### PR TITLE
Fix pizza name overflow

### DIFF
--- a/lib/ui/screens/food_screen.dart
+++ b/lib/ui/screens/food_screen.dart
@@ -467,19 +467,20 @@ class __ProductTileState extends State<_ProductTile> {
   @override
   Widget build(BuildContext context) {
     return ListTile(
-      horizontalTitleGap: 4,
-      leading: const Icon(Icons.local_pizza),
-      title: Row(
-        children: [
-          Text(widget.product.name),
-          const SizedBox(width: 6),
-          Text(
-            '€${widget.product.price}',
-            style: Theme.of(context).textTheme.caption!.copyWith(
-              fontFeatures: const [FontFeature.tabularFigures()],
+      title: Text.rich(
+        TextSpan(
+          children: [
+            TextSpan(text: widget.product.name + ' '),
+            TextSpan(
+              text: '€${widget.product.price}',
+              style: Theme.of(context).textTheme.caption!.copyWith(
+                fontFeatures: const [FontFeature.tabularFigures()],
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
       ),
       subtitle: widget.product.description.isNotEmpty
           ? Text(widget.product.description)


### PR DESCRIPTION
Closes #158.

Sorry @Jorritboer I stole your issue just to have something to do.

Removes the pizza icon and adds ellipsis to food product names. In case of ellipsis, the price is removed first, but with the icon removed it's unlikely that ellipsis occur at all.
