### PR TITLE
Fix outdated search results

### DIFF
--- a/lib/blocs/album_list_cubit.dart
+++ b/lib/blocs/album_list_cubit.dart
@@ -32,11 +32,15 @@ class AlbumListCubit extends Cubit<AlbumListState> {
     emit(state.copyWith(isLoading: true));
     try {
       final query = _searchQuery;
-      var albumsResponse = await api.getAlbums(
+      final albumsResponse = await api.getAlbums(
         search: query,
         limit: firstPageSize,
         offset: 0,
       );
+
+      // Discard result if _searchQuery has
+      // changed since the request was made.
+      if (query != _searchQuery) return;
 
       final isDone = albumsResponse.results.length == albumsResponse.count;
 
@@ -72,11 +76,15 @@ class AlbumListCubit extends Cubit<AlbumListState> {
       final query = _searchQuery;
 
       // Get next page of albums.
-      var albumsResponse = await api.getAlbums(
+      final albumsResponse = await api.getAlbums(
         search: query,
         limit: pageSize,
         offset: _nextOffset,
       );
+
+      // Discard result if _searchQuery has
+      // changed since the request was made.
+      if (query != _searchQuery) return;
 
       final albums = state.results + albumsResponse.results;
       final isDone = albums.length == albumsResponse.count;

--- a/lib/blocs/calendar_cubit.dart
+++ b/lib/blocs/calendar_cubit.dart
@@ -150,6 +150,10 @@ class CalendarCubit extends Cubit<CalendarState> {
         offset: 0,
       );
 
+      // Discard result if _searchQuery has
+      // changed since the request was made.
+      if (query != _searchQuery) return;
+
       final isDone = eventsResponse.results.length == eventsResponse.count;
 
       _nextOffset = firstPageSize;
@@ -233,6 +237,10 @@ class CalendarCubit extends Cubit<CalendarState> {
         limit: pageSize,
         offset: _nextOffset,
       );
+
+      // Discard result if _searchQuery has
+      // changed since the request was made.
+      if (query != _searchQuery) return;
 
       final isDone =
           _nextOffset + eventsResponse.results.length == eventsResponse.count;

--- a/lib/blocs/event_admin_cubit.dart
+++ b/lib/blocs/event_admin_cubit.dart
@@ -87,12 +87,16 @@ class EventAdminCubit extends Cubit<EventAdminState> {
     try {
       final query = _searchQuery;
       final event = await api.getEvent(pk: eventPk);
-      var registrations = await api.getAdminEventRegistrations(
+      final registrations = await api.getAdminEventRegistrations(
         pk: eventPk,
         search: query,
         limit: 999999999,
         cancelled: false,
       );
+
+      // Discard result if _searchQuery has
+      // changed since the request was made.
+      if (query != _searchQuery) return;
 
       // temporary fix, remove when api is updated
       registrations.results.removeWhere((r) => r.queuePosition != null);
@@ -129,6 +133,10 @@ class EventAdminCubit extends Cubit<EventAdminState> {
           limit: 999999999,
           cancelled: false,
         );
+
+        // Discard result if _searchQuery has
+        // changed since the request was made.
+        if (query != _searchQuery) return;
 
         // temporary fix, remove when api is updated
         registrations.results.removeWhere((r) => r.queuePosition != null);

--- a/lib/blocs/food_admin_cubit.dart
+++ b/lib/blocs/food_admin_cubit.dart
@@ -30,7 +30,15 @@ class FoodAdminCubit extends Cubit<FoodAdminState> {
     try {
       final query = _searchQuery;
       final orders = await api.getAdminFoodOrders(
-          pk: foodEventPk, search: query, limit: 999999999);
+        pk: foodEventPk,
+        search: query,
+        limit: 999999999,
+      );
+
+      // Discard result if _searchQuery has
+      // changed since the request was made.
+      if (query != _searchQuery) return;
+
       if (orders.results.isEmpty) {
         if (query?.isEmpty ?? true) {
           emit(const FoodAdminState.failure(

--- a/lib/blocs/member_list_cubit.dart
+++ b/lib/blocs/member_list_cubit.dart
@@ -32,11 +32,15 @@ class MemberListCubit extends Cubit<MemberListState> {
     emit(state.copyWith(isLoading: true));
     try {
       final query = _searchQuery;
-      var membersResponse = await api.getMembers(
+      final membersResponse = await api.getMembers(
         search: query,
         limit: firstPageSize,
         offset: 0,
       );
+
+      // Discard result if _searchQuery has
+      // changed since the request was made.
+      if (query != _searchQuery) return;
 
       final isDone = membersResponse.results.length == membersResponse.count;
 
@@ -72,11 +76,15 @@ class MemberListCubit extends Cubit<MemberListState> {
       final query = _searchQuery;
 
       // Get next page of albums.
-      var membersResponse = await api.getMembers(
+      final membersResponse = await api.getMembers(
         search: query,
         limit: pageSize,
         offset: _nextOffset,
       );
+
+      // Discard result if _searchQuery has
+      // changed since the request was made.
+      if (query != _searchQuery) return;
 
       final members = state.results + membersResponse.results;
       final isDone = members.length == membersResponse.count;

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api_repository.dart';


### PR DESCRIPTION
This fixes a problem where incorrect search results may appear. When an api call was triggered, its result was used even if during the asynchronous gap, something changes such that the result should no longer be used. For example:

- When searching for 'a', a timer is started.
- After 300ms, an http request is sent. 
- Before the corresponding response is received, the user removes the query, so the state should remain loading.
- The response arrives, and handling of the old 'a' search continues, emitting a new incorrect state.

This PR eliminates the problem by discarding a response if the search query has changed. Note that exceptions thrown in the api call will still result in an exception state being emitted.
