### PR TITLE
Add download button for images

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.thaliapp">
+
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <application
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -42,6 +42,8 @@ PODS:
   - FMDB (2.7.5):
     - FMDB/standard (= 2.7.5)
   - FMDB/standard (2.7.5)
+  - gallery_saver (0.0.1):
+    - Flutter
   - GoogleDataTransport (9.1.2):
     - GoogleUtilities/Environment (~> 7.2)
     - nanopb (~> 2.30908.0)
@@ -102,6 +104,7 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_web_auth (from `.symlinks/plugins/flutter_web_auth/ios`)
+  - gallery_saver (from `.symlinks/plugins/gallery_saver/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -138,6 +141,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_secure_storage/ios"
   flutter_web_auth:
     :path: ".symlinks/plugins/flutter_web_auth/ios"
+  gallery_saver:
+    :path: ".symlinks/plugins/gallery_saver/ios"
   image_cropper:
     :path: ".symlinks/plugins/image_cropper/ios"
   image_picker:
@@ -169,6 +174,7 @@ SPEC CHECKSUMS:
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
   flutter_web_auth: fd071763f61703882adbb2524f5cd5251883118c
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
+  gallery_saver: 9fc173c9f4fcc48af53b2a9ebea1b643255be542
   GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   image_cropper: f1668dd8d2cad2d357955caad15a40547856edcb

--- a/lib/ui/screens/album_screen.dart
+++ b/lib/ui/screens/album_screen.dart
@@ -100,6 +100,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                         behavior: SnackBarBehavior.floating,
+                        duration: Duration(seconds: 2),
                         content: Text('Could not download the image.'),
                       ),
                     );
@@ -174,7 +175,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
           await Share.share('https://${config.apiHost}/members/photos/$slug/');
         } catch (_) {
           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-            duration: Duration(seconds: 1),
+            duration: Duration(seconds: 2),
             content: Text('Could not share the album.'),
           ));
         }

--- a/lib/ui/screens/album_screen.dart
+++ b/lib/ui/screens/album_screen.dart
@@ -13,6 +13,7 @@ import 'package:reaxit/ui/widgets/app_bar.dart';
 import 'package:reaxit/ui/widgets/error_scroll_view.dart';
 import 'package:reaxit/config.dart' as config;
 import 'package:share_plus/share_plus.dart';
+import 'package:gallery_saver/gallery_saver.dart';
 
 /// Screen that loads and shows a the Album of the member with `slug`.
 class AlbumScreen extends StatefulWidget {
@@ -70,6 +71,41 @@ class _AlbumScreenState extends State<AlbumScreen> {
               color: Theme.of(context).primaryIconTheme.color,
             ),
             actions: [
+              IconButton(
+                padding: const EdgeInsets.all(16),
+                color: Theme.of(context).primaryIconTheme.color,
+                icon: const Icon(Icons.download),
+                onPressed: () async {
+                  var i = pageController.page!.round();
+                  if (i < 0 || i >= album.photos.length) i = index;
+                  final url = Uri.parse(album.photos[i].full);
+                  try {
+                    final response = await http.get(url);
+                    if (response.statusCode != 200) throw Exception();
+                    final baseTempDir = await getTemporaryDirectory();
+                    final tempDir = await baseTempDir.createTemp();
+                    final tempFile = File(
+                      '${tempDir.path}/${url.pathSegments.last}',
+                    );
+                    await tempFile.writeAsBytes(response.bodyBytes);
+                    await GallerySaver.saveImage(tempFile.path);
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        behavior: SnackBarBehavior.floating,
+                        duration: Duration(seconds: 2),
+                        content: Text('Succesfully saved the image.'),
+                      ),
+                    );
+                  } catch (_) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(
+                        behavior: SnackBarBehavior.floating,
+                        content: Text('Could not download the image.'),
+                      ),
+                    );
+                  }
+                },
+              ),
               IconButton(
                 padding: const EdgeInsets.all(16),
                 color: Theme.of(context).primaryIconTheme.color,

--- a/lib/ui/screens/album_screen.dart
+++ b/lib/ui/screens/album_screen.dart
@@ -92,7 +92,6 @@ class _AlbumScreenState extends State<AlbumScreen> {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                         behavior: SnackBarBehavior.floating,
-                        duration: Duration(seconds: 2),
                         content: Text('Succesfully saved the image.'),
                       ),
                     );
@@ -100,7 +99,6 @@ class _AlbumScreenState extends State<AlbumScreen> {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(
                         behavior: SnackBarBehavior.floating,
-                        duration: Duration(seconds: 2),
                         content: Text('Could not download the image.'),
                       ),
                     );
@@ -175,7 +173,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
           await Share.share('https://${config.apiHost}/members/photos/$slug/');
         } catch (_) {
           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-            duration: Duration(seconds: 2),
+            behavior: SnackBarBehavior.floating,
             content: Text('Could not share the album.'),
           ));
         }

--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -212,7 +212,6 @@ class __RegistrationTileState extends State<_RegistrationTile> {
                 content: Text(value != null
                     ? 'Could not mark $name as paid.'
                     : 'Could not mark $name as not paid.'),
-                duration: const Duration(seconds: 1),
               ));
             }
           },

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -930,7 +930,7 @@ class _EventScreenState extends State<EventScreen> {
           await Share.share('https://${config.apiHost}/events/$pk/');
         } catch (_) {
           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
-            duration: Duration(seconds: 1),
+            behavior: SnackBarBehavior.floating,
             content: Text('Could not share the event.'),
           ));
         }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -429,6 +429,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.7.3+1"
+  gallery_saver:
+    dependency: "direct main"
+    description:
+      name: gallery_saver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.2"
   glob:
     dependency: transitive
     description:
@@ -449,7 +456,7 @@ packages:
       name: google_fonts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   graphs:
     dependency: transitive
     description:
@@ -505,7 +512,7 @@ packages:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+6"
+    version: "0.8.4+7"
   image_picker_for_web:
     dependency: transitive
     description:
@@ -981,7 +988,7 @@ packages:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1+1"
+    version: "2.2.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1072,14 +1079,14 @@ packages:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.14"
+    version: "6.0.15"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.14"
+    version: "6.0.15"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -1107,7 +1114,7 @@ packages:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -1149,7 +1156,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.6"
+    version: "2.3.11"
   xdg_directories:
     dependency: transitive
     description:
@@ -1173,4 +1180,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.16.0 <3.0.0"
-  flutter: ">=2.6.0-0"
+  flutter: ">=2.10.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,6 +81,7 @@ dependencies:
   
   # Access camera and gallery.
   image_picker: ^0.8.4+4
+  gallery_saver:
 
   # Resize images.
   image_cropper: ^1.4.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -81,7 +81,7 @@ dependencies:
   
   # Access camera and gallery.
   image_picker: ^0.8.4+4
-  gallery_saver:
+  gallery_saver: ^2.3.2
 
   # Resize images.
   image_cropper: ^1.4.1


### PR DESCRIPTION
Closes #171 

<!--

Please add the appropriate label for the change that you made to this PR:
- feature: new feature for the user, not a new feature for build script
- bug: fix for the user, not a fix to a build script
- docs: changes to the documentation
- refactor: refactoring production code, eg. renaming a variable or rewriting a function
- test: adding missing tests, refactoring tests; no production code change
- chore: updating a tool, changing the CI settings etc; no production code change

-->

### Summary
Add a download button to save photos to gallery.

### How to test
Steps to test the changes you made:
1. Go to photos, open some album
2. view a photo
3. use the download-button in the top-right to save the photo in your gallery
