### PR TITLE
Add groups screen to app

### DIFF
--- a/lib/api/api_repository.dart
+++ b/lib/api/api_repository.dart
@@ -334,10 +334,11 @@ abstract class ApiRepository {
   /// Get the list of all [PushNoficationCategory]s.
   Future<ListResponse<PushNotificationCategory>> getCategories();
 
-  /// Get a list of groups.
+  /// Get a list of [ListGroup]s.
   ///
-  /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
-  /// total number of [ListGroup]s that can be returned.
+  /// Use `limit` and `offset` for pagination, and `type`, `start`, `end` and
+  /// `search for filtering. [ListResponse.count] is the total number of
+  /// [ListGroup]s that can be returned.
   Future<ListResponse<ListGroup>> getGroups({
     int? limit,
     int? offset,
@@ -347,9 +348,6 @@ abstract class ApiRepository {
     String? search,
   });
 
-  /// Get a list of groups.
-  ///
-  /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
-  /// total number of [ListGroup]s that can be returned.
+  /// Get the [Group] with the `pk`.
   Future<Group> getGroup({required int pk});
 }

--- a/lib/api/api_repository.dart
+++ b/lib/api/api_repository.dart
@@ -342,4 +342,7 @@ abstract class ApiRepository {
       DateTime? start,
       DateTime? end,
       String? search});
+
+  Future<Group> getGroup(
+      {required int pk});
 }

--- a/lib/api/api_repository.dart
+++ b/lib/api/api_repository.dart
@@ -343,6 +343,5 @@ abstract class ApiRepository {
       DateTime? end,
       String? search});
 
-  Future<Group> getGroup(
-      {required int pk});
+  Future<Group> getGroup({required int pk});
 }

--- a/lib/api/api_repository.dart
+++ b/lib/api/api_repository.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:reaxit/models/album.dart';
+import 'package:reaxit/models/group.dart';
 import 'package:reaxit/models/push_notification_category.dart';
 import 'package:reaxit/models/event.dart';
 import 'package:reaxit/models/event_registration.dart';
@@ -332,4 +333,13 @@ abstract class ApiRepository {
 
   /// Get the list of all [PushNoficationCategory]s.
   Future<ListResponse<PushNotificationCategory>> getCategories();
+
+  /// Get a list of groups.
+  Future<ListResponse<ListGroup>> getGroups(
+      {int? limit,
+      int? offset,
+      MemberGroupType? type,
+      DateTime? start,
+      DateTime? end,
+      String? search});
 }

--- a/lib/api/api_repository.dart
+++ b/lib/api/api_repository.dart
@@ -335,13 +335,21 @@ abstract class ApiRepository {
   Future<ListResponse<PushNotificationCategory>> getCategories();
 
   /// Get a list of groups.
-  Future<ListResponse<ListGroup>> getGroups(
-      {int? limit,
-      int? offset,
-      MemberGroupType? type,
-      DateTime? start,
-      DateTime? end,
-      String? search});
+  ///
+  /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
+  /// total number of [ListGroup]s that can be returned.
+  Future<ListResponse<ListGroup>> getGroups({
+    int? limit,
+    int? offset,
+    MemberGroupType? type,
+    DateTime? start,
+    DateTime? end,
+    String? search,
+  });
 
+  /// Get a list of groups.
+  ///
+  /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
+  /// total number of [ListGroup]s that can be returned.
   Future<Group> getGroup({required int pk});
 }

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -1148,7 +1148,7 @@ class ConcrexitApiRepository implements ApiRepository {
   @override
   Future<Group> getGroup({required int pk}) async {
     final uri = _baseUri.replace(
-      path: '$_basePath/activemembers/groups/' + pk.toString() + '/',
+      path: '$_basePath/activemembers/groups/$pk/',
       queryParameters: {},
     );
 

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -7,6 +7,7 @@ import 'package:oauth2/oauth2.dart' as oauth2;
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/config.dart' as config;
 import 'package:reaxit/models/album.dart';
+import 'package:reaxit/models/group.dart';
 import 'package:reaxit/models/push_notification_category.dart';
 import 'package:reaxit/models/event.dart';
 import 'package:reaxit/models/event_registration.dart';
@@ -1109,6 +1110,42 @@ class ConcrexitApiRepository implements ApiRepository {
     } catch (e) {
       _catch(e);
     }
+  }
+
+  /// Get a list of groups.
+  ///
+  /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
+  /// total number of [ListGroup]s that can be returned.
+  Future<ListResponse<ListGroup>> getGroups(
+      {int? limit,
+      int? offset,
+      MemberGroupType? type,
+      DateTime? start,
+      DateTime? end,
+      String? search}) async {
+    const memberGroupTypeMap = {
+      MemberGroupType.committee: 'committee',
+      MemberGroupType.society: 'society',
+      MemberGroupType.board: 'board',
+    };
+
+    final uri = _baseUri.replace(
+      path: '$_basePath/activemembers/groups/',
+      queryParameters: {
+        if (limit != null) 'limit': limit.toString(),
+        if (offset != null) 'offset': offset.toString(),
+        if (type != null) 'type': memberGroupTypeMap[type],
+        if (start != null) 'start': start.toIso8601String(),
+        if (end != null) 'end': end.toIso8601String(),
+        if (search != null) 'search': search
+      },
+    );
+
+    final response = await _handleExceptions(() => _client.get(uri));
+    return ListResponse<ListGroup>.fromJson(
+      _jsonDecode(response),
+      (json) => ListGroup.fromJson(json as Map<String, dynamic>),
+    );
   }
 // TODO: Someday: move json parsing of lists into isolates?
 // TODO: Someday: change ApiException to a class that can contain a string?

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -1152,11 +1152,9 @@ class ConcrexitApiRepository implements ApiRepository {
   ///
   /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
   /// total number of [ListGroup]s that can be returned.
-  Future<Group> getGroup(
-      {required int pk}) async {
-
+  Future<Group> getGroup({required int pk}) async {
     final uri = _baseUri.replace(
-      path: '$_basePath/activemembers/groups/'+pk.toString()+'/',
+      path: '$_basePath/activemembers/groups/' + pk.toString() + '/',
       queryParameters: {},
     );
 

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -1112,10 +1112,6 @@ class ConcrexitApiRepository implements ApiRepository {
     }
   }
 
-  /// Get a list of groups.
-  ///
-  /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
-  /// total number of [ListGroup]s that can be returned.
   @override
   Future<ListResponse<ListGroup>> getGroups(
       {int? limit,
@@ -1149,10 +1145,6 @@ class ConcrexitApiRepository implements ApiRepository {
     );
   }
 
-  /// Get a list of groups.
-  ///
-  /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
-  /// total number of [ListGroup]s that can be returned.
   @override
   Future<Group> getGroup({required int pk}) async {
     final uri = _baseUri.replace(

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -1113,13 +1113,14 @@ class ConcrexitApiRepository implements ApiRepository {
   }
 
   @override
-  Future<ListResponse<ListGroup>> getGroups(
-      {int? limit,
-      int? offset,
-      MemberGroupType? type,
-      DateTime? start,
-      DateTime? end,
-      String? search}) async {
+  Future<ListResponse<ListGroup>> getGroups({
+    int? limit,
+    int? offset,
+    MemberGroupType? type,
+    DateTime? start,
+    DateTime? end,
+    String? search,
+  }) async {
     const memberGroupTypeMap = {
       MemberGroupType.committee: 'committee',
       MemberGroupType.society: 'society',
@@ -1147,11 +1148,7 @@ class ConcrexitApiRepository implements ApiRepository {
 
   @override
   Future<Group> getGroup({required int pk}) async {
-    final uri = _baseUri.replace(
-      path: '$_basePath/activemembers/groups/$pk/',
-      queryParameters: {},
-    );
-
+    final uri = _baseUri.replace(path: '$_basePath/activemembers/groups/$pk/');
     final response = await _handleExceptions(() => _client.get(uri));
     return Group.fromJson(_jsonDecode(response));
   }

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -1147,6 +1147,22 @@ class ConcrexitApiRepository implements ApiRepository {
       (json) => ListGroup.fromJson(json as Map<String, dynamic>),
     );
   }
+
+  /// Get a list of groups.
+  ///
+  /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
+  /// total number of [ListGroup]s that can be returned.
+  Future<Group> getGroup(
+      {required int pk}) async {
+
+    final uri = _baseUri.replace(
+      path: '$_basePath/activemembers/groups/'+pk.toString()+'/',
+      queryParameters: {},
+    );
+
+    final response = await _handleExceptions(() => _client.get(uri));
+    return Group.fromJson(_jsonDecode(response));
+  }
 // TODO: Someday: move json parsing of lists into isolates?
 // TODO: Someday: change ApiException to a class that can contain a string?
 //  We can then display more specific error messages to the user based on

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -1116,6 +1116,7 @@ class ConcrexitApiRepository implements ApiRepository {
   ///
   /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
   /// total number of [ListGroup]s that can be returned.
+  @override
   Future<ListResponse<ListGroup>> getGroups(
       {int? limit,
       int? offset,
@@ -1152,6 +1153,7 @@ class ConcrexitApiRepository implements ApiRepository {
   ///
   /// Use `limit` and `offset` for pagination. [ListResponse.count] is the
   /// total number of [ListGroup]s that can be returned.
+  @override
   Future<Group> getGroup({required int pk}) async {
     final uri = _baseUri.replace(
       path: '$_basePath/activemembers/groups/' + pk.toString() + '/',

--- a/lib/blocs/boards_cubit.dart
+++ b/lib/blocs/boards_cubit.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reaxit/api/api_repository.dart';
+import 'package:reaxit/blocs/detail_state.dart';
+import 'package:reaxit/models/group.dart';
+
+class BoardsCubit extends Cubit<DetailState<List<ListGroup>>> {
+  final ApiRepository api;
+
+  BoardsCubit(this.api) : super(const DetailState<List<ListGroup>>.loading());
+
+  Future<void> load() async {
+    emit(state.copyWith(isLoading: true));
+    try {
+      final listResponse = await api.getGroups(
+          limit: 1000, offset: 0, type: MemberGroupType.board);
+      if (listResponse.results.isNotEmpty) {
+        emit(DetailState.result(result: listResponse.results));
+      } else {
+        emit(const DetailState.failure(message: 'There are no boards.'));
+      }
+    } on ApiException catch (exception) {
+      emit(DetailState.failure(message: _failureMessage(exception)));
+    }
+  }
+
+  String _failureMessage(ApiException exception) {
+    switch (exception) {
+      case ApiException.noInternet:
+        return 'Not connected to the internet.';
+      default:
+        return 'An unknown error occurred.';
+    }
+  }
+}

--- a/lib/blocs/boards_cubit.dart
+++ b/lib/blocs/boards_cubit.dart
@@ -3,26 +3,27 @@ import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/blocs/detail_state.dart';
 import 'package:reaxit/models/group.dart';
 
-class BoardsCubit extends Cubit<DetailState<List<ListGroup>>> {
+typedef BoardsState = DetailState<List<ListGroup>>;
+
+class BoardsCubit extends Cubit<BoardsState> {
   final ApiRepository api;
 
-  BoardsCubit(this.api) : super(const DetailState<List<ListGroup>>.loading());
+  BoardsCubit(this.api) : super(const BoardsState.loading());
 
   Future<void> load() async {
     emit(state.copyWith(isLoading: true));
     try {
       final listResponse = await api.getGroups(
         limit: 1000,
-        offset: 0,
         type: MemberGroupType.board,
       );
       if (listResponse.results.isNotEmpty) {
-        emit(DetailState.result(result: listResponse.results));
+        emit(BoardsState.result(result: listResponse.results));
       } else {
-        emit(const DetailState.failure(message: 'There are no boards.'));
+        emit(const BoardsState.failure(message: 'There are no boards.'));
       }
     } on ApiException catch (exception) {
-      emit(DetailState.failure(message: _failureMessage(exception)));
+      emit(BoardsState.failure(message: _failureMessage(exception)));
     }
   }
 
@@ -30,8 +31,6 @@ class BoardsCubit extends Cubit<DetailState<List<ListGroup>>> {
     switch (exception) {
       case ApiException.noInternet:
         return 'Not connected to the internet.';
-      case ApiException.notFound:
-        return 'This page could not be found.';
       default:
         return 'An unknown error occurred.';
     }

--- a/lib/blocs/boards_cubit.dart
+++ b/lib/blocs/boards_cubit.dart
@@ -12,7 +12,10 @@ class BoardsCubit extends Cubit<DetailState<List<ListGroup>>> {
     emit(state.copyWith(isLoading: true));
     try {
       final listResponse = await api.getGroups(
-          limit: 1000, offset: 0, type: MemberGroupType.board);
+        limit: 1000,
+        offset: 0,
+        type: MemberGroupType.board,
+      );
       if (listResponse.results.isNotEmpty) {
         emit(DetailState.result(result: listResponse.results));
       } else {
@@ -27,6 +30,8 @@ class BoardsCubit extends Cubit<DetailState<List<ListGroup>>> {
     switch (exception) {
       case ApiException.noInternet:
         return 'Not connected to the internet.';
+      case ApiException.notFound:
+        return 'This page could not be found.';
       default:
         return 'An unknown error occurred.';
     }

--- a/lib/blocs/committees_cubit.dart
+++ b/lib/blocs/committees_cubit.dart
@@ -3,27 +3,28 @@ import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/blocs/detail_state.dart';
 import 'package:reaxit/models/group.dart';
 
-class CommitteesCubit extends Cubit<DetailState<List<ListGroup>>> {
+typedef CommitteesState = DetailState<List<ListGroup>>;
+
+class CommitteesCubit extends Cubit<CommitteesState> {
   final ApiRepository api;
 
-  CommitteesCubit(this.api)
-      : super(const DetailState<List<ListGroup>>.loading());
+  CommitteesCubit(this.api) : super(const CommitteesState.loading());
 
   Future<void> load() async {
     emit(state.copyWith(isLoading: true));
     try {
       final listResponse = await api.getGroups(
         limit: 1000,
-        offset: 0,
         type: MemberGroupType.committee,
       );
       if (listResponse.results.isNotEmpty) {
-        emit(DetailState.result(result: listResponse.results));
+        emit(CommitteesState.result(result: listResponse.results));
       } else {
-        emit(const DetailState.failure(message: 'There are no committees.'));
+        emit(
+            const CommitteesState.failure(message: 'There are no committees.'));
       }
     } on ApiException catch (exception) {
-      emit(DetailState.failure(message: _failureMessage(exception)));
+      emit(CommitteesState.failure(message: _failureMessage(exception)));
     }
   }
 
@@ -31,8 +32,6 @@ class CommitteesCubit extends Cubit<DetailState<List<ListGroup>>> {
     switch (exception) {
       case ApiException.noInternet:
         return 'Not connected to the internet.';
-      case ApiException.notFound:
-        return 'This page could not be found.';
       default:
         return 'An unknown error occurred.';
     }

--- a/lib/blocs/committees_cubit.dart
+++ b/lib/blocs/committees_cubit.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reaxit/api/api_repository.dart';
+import 'package:reaxit/blocs/detail_state.dart';
+import 'package:reaxit/models/group.dart';
+
+class CommitteesCubit extends Cubit<DetailState<List<ListGroup>>> {
+  final ApiRepository api;
+
+  CommitteesCubit(this.api)
+      : super(const DetailState<List<ListGroup>>.loading());
+
+  Future<void> load() async {
+    emit(state.copyWith(isLoading: true));
+    try {
+      final listResponse = await api.getGroups(
+          limit: 1000, offset: 0, type: MemberGroupType.committee);
+      if (listResponse.results.isNotEmpty) {
+        emit(DetailState.result(result: listResponse.results));
+      } else {
+        emit(const DetailState.failure(message: 'There are no committees.'));
+      }
+    } on ApiException catch (exception) {
+      emit(DetailState.failure(message: _failureMessage(exception)));
+    }
+  }
+
+  String _failureMessage(ApiException exception) {
+    switch (exception) {
+      case ApiException.noInternet:
+        return 'Not connected to the internet.';
+      default:
+        return 'An unknown error occurred.';
+    }
+  }
+}

--- a/lib/blocs/committees_cubit.dart
+++ b/lib/blocs/committees_cubit.dart
@@ -13,7 +13,10 @@ class CommitteesCubit extends Cubit<DetailState<List<ListGroup>>> {
     emit(state.copyWith(isLoading: true));
     try {
       final listResponse = await api.getGroups(
-          limit: 1000, offset: 0, type: MemberGroupType.committee);
+        limit: 1000,
+        offset: 0,
+        type: MemberGroupType.committee,
+      );
       if (listResponse.results.isNotEmpty) {
         emit(DetailState.result(result: listResponse.results));
       } else {
@@ -28,6 +31,8 @@ class CommitteesCubit extends Cubit<DetailState<List<ListGroup>>> {
     switch (exception) {
       case ApiException.noInternet:
         return 'Not connected to the internet.';
+      case ApiException.notFound:
+        return 'This page could not be found.';
       default:
         return 'An unknown error occurred.';
     }

--- a/lib/blocs/group_cubit.dart
+++ b/lib/blocs/group_cubit.dart
@@ -1,0 +1,34 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reaxit/api/api_repository.dart';
+import 'package:reaxit/blocs/detail_state.dart';
+import 'package:reaxit/models/group.dart';
+
+class GroupCubit extends Cubit<DetailState<Group>> {
+  final ApiRepository api;
+  final int pk;
+
+  GroupCubit(this.api, {required this.pk}) : super(const DetailState<Group>.loading());
+
+  Future<void> load() async {
+    emit(state.copyWith(isLoading: true));
+    try {
+      final groupResponse = await api.getGroup(pk: pk);
+      if (groupResponse != null) {
+        emit(DetailState.result(result: groupResponse));
+      } else {
+        emit(const DetailState.failure(message: 'There exists no group with this pk.'));
+      }
+    } on ApiException catch (exception) {
+      emit(DetailState.failure(message: _failureMessage(exception)));
+    }
+  }
+
+  String _failureMessage(ApiException exception) {
+    switch (exception) {
+      case ApiException.noInternet:
+        return 'Not connected to the internet.';
+      default:
+        return 'An unknown error occurred.';
+    }
+  }
+}

--- a/lib/blocs/group_cubit.dart
+++ b/lib/blocs/group_cubit.dart
@@ -16,12 +16,7 @@ class GroupCubit extends Cubit<GroupState> {
     emit(state.copyWith(isLoading: true));
     try {
       final groupResponse = await api.getGroup(pk: pk);
-      if (groupResponse != null) {
-        emit(DetailState.result(result: groupResponse));
-      } else {
-        emit(const DetailState.failure(
-            message: 'There exists no group with this pk.'));
-      }
+      emit(DetailState.result(result: groupResponse));
     } on ApiException catch (exception) {
       emit(DetailState.failure(message: _failureMessage(exception)));
     }

--- a/lib/blocs/group_cubit.dart
+++ b/lib/blocs/group_cubit.dart
@@ -26,6 +26,8 @@ class GroupCubit extends Cubit<GroupState> {
     switch (exception) {
       case ApiException.noInternet:
         return 'Not connected to the internet.';
+      case ApiException.notFound:
+        return 'The group does not exist.';
       default:
         return 'An unknown error occurred.';
     }

--- a/lib/blocs/group_cubit.dart
+++ b/lib/blocs/group_cubit.dart
@@ -3,11 +3,14 @@ import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/blocs/detail_state.dart';
 import 'package:reaxit/models/group.dart';
 
-class GroupCubit extends Cubit<DetailState<Group>> {
+typedef GroupState = DetailState<Group>;
+
+class GroupCubit extends Cubit<GroupState> {
   final ApiRepository api;
   final int pk;
 
-  GroupCubit(this.api, {required this.pk}) : super(const DetailState<Group>.loading());
+  GroupCubit(this.api, {required this.pk})
+      : super(const DetailState<Group>.loading());
 
   Future<void> load() async {
     emit(state.copyWith(isLoading: true));
@@ -16,7 +19,8 @@ class GroupCubit extends Cubit<DetailState<Group>> {
       if (groupResponse != null) {
         emit(DetailState.result(result: groupResponse));
       } else {
-        emit(const DetailState.failure(message: 'There exists no group with this pk.'));
+        emit(const DetailState.failure(
+            message: 'There exists no group with this pk.'));
       }
     } on ApiException catch (exception) {
       emit(DetailState.failure(message: _failureMessage(exception)));

--- a/lib/blocs/societies_cubit.dart
+++ b/lib/blocs/societies_cubit.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reaxit/api/api_repository.dart';
+import 'package:reaxit/blocs/detail_state.dart';
+import 'package:reaxit/models/group.dart';
+
+class SocietiesCubit extends Cubit<DetailState<List<ListGroup>>> {
+  final ApiRepository api;
+
+  SocietiesCubit(this.api)
+      : super(const DetailState<List<ListGroup>>.loading());
+
+  Future<void> load() async {
+    emit(state.copyWith(isLoading: true));
+    try {
+      final listResponse = await api.getGroups(
+          limit: 1000, offset: 0, type: MemberGroupType.society);
+      if (listResponse.results.isNotEmpty) {
+        emit(DetailState.result(result: listResponse.results));
+      } else {
+        emit(const DetailState.failure(message: 'There are no societies.'));
+      }
+    } on ApiException catch (exception) {
+      emit(DetailState.failure(message: _failureMessage(exception)));
+    }
+  }
+
+  String _failureMessage(ApiException exception) {
+    switch (exception) {
+      case ApiException.noInternet:
+        return 'Not connected to the internet.';
+      default:
+        return 'An unknown error occurred.';
+    }
+  }
+}

--- a/lib/blocs/societies_cubit.dart
+++ b/lib/blocs/societies_cubit.dart
@@ -3,27 +3,27 @@ import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/blocs/detail_state.dart';
 import 'package:reaxit/models/group.dart';
 
-class SocietiesCubit extends Cubit<DetailState<List<ListGroup>>> {
+typedef SocietiesState = DetailState<List<ListGroup>>;
+
+class SocietiesCubit extends Cubit<SocietiesState> {
   final ApiRepository api;
 
-  SocietiesCubit(this.api)
-      : super(const DetailState<List<ListGroup>>.loading());
+  SocietiesCubit(this.api) : super(const SocietiesState.loading());
 
   Future<void> load() async {
     emit(state.copyWith(isLoading: true));
     try {
       final listResponse = await api.getGroups(
         limit: 1000,
-        offset: 0,
         type: MemberGroupType.society,
       );
       if (listResponse.results.isNotEmpty) {
-        emit(DetailState.result(result: listResponse.results));
+        emit(SocietiesState.result(result: listResponse.results));
       } else {
-        emit(const DetailState.failure(message: 'There are no societies.'));
+        emit(const SocietiesState.failure(message: 'There are no societies.'));
       }
     } on ApiException catch (exception) {
-      emit(DetailState.failure(message: _failureMessage(exception)));
+      emit(SocietiesState.failure(message: _failureMessage(exception)));
     }
   }
 

--- a/lib/blocs/societies_cubit.dart
+++ b/lib/blocs/societies_cubit.dart
@@ -13,7 +13,10 @@ class SocietiesCubit extends Cubit<DetailState<List<ListGroup>>> {
     emit(state.copyWith(isLoading: true));
     try {
       final listResponse = await api.getGroups(
-          limit: 1000, offset: 0, type: MemberGroupType.society);
+        limit: 1000,
+        offset: 0,
+        type: MemberGroupType.society,
+      );
       if (listResponse.results.isNotEmpty) {
         emit(DetailState.result(result: listResponse.results));
       } else {
@@ -28,6 +31,8 @@ class SocietiesCubit extends Cubit<DetailState<List<ListGroup>>> {
     switch (exception) {
       case ApiException.noInternet:
         return 'Not connected to the internet.';
+      case ApiException.notFound:
+        return 'This page could not be found.';
       default:
         return 'An unknown error occurred.';
     }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,9 @@ import 'package:reaxit/blocs/payment_user_cubit.dart';
 import 'package:reaxit/blocs/setting_cubit.dart';
 import 'package:reaxit/blocs/theme_cubit.dart';
 import 'package:reaxit/blocs/welcome_cubit.dart';
+import 'package:reaxit/blocs/boards_cubit.dart';
+import 'package:reaxit/blocs/committees_cubit.dart';
+import 'package:reaxit/blocs/societies_cubit.dart';
 import 'package:reaxit/config.dart' as config;
 import 'package:reaxit/routes.dart';
 import 'package:reaxit/ui/screens/login_screen.dart';
@@ -238,6 +241,24 @@ class _ThaliAppState extends State<ThaliApp> {
                       )..load(),
                       lazy: false,
                     ),
+                    BlocProvider(
+                      create: (_) => CommitteesCubit(
+                        authState.apiRepository,
+                      )..load(),
+                      lazy: false,
+                    ),
+                    BlocProvider(
+                      create: (_) => BoardsCubit(
+                        authState.apiRepository,
+                      )..load(),
+                      lazy: false,
+                    ),
+                    BlocProvider(
+                      create: (_) => SocietiesCubit(
+                        authState.apiRepository,
+                      )..load(),
+                      lazy: false,
+                    )
                   ],
                   child: navigator,
                 ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -245,19 +245,19 @@ class _ThaliAppState extends State<ThaliApp> {
                       create: (_) => CommitteesCubit(
                         authState.apiRepository,
                       )..load(),
-                      lazy: false,
+                      lazy: true,
                     ),
                     BlocProvider(
                       create: (_) => BoardsCubit(
                         authState.apiRepository,
                       )..load(),
-                      lazy: false,
+                      lazy: true,
                     ),
                     BlocProvider(
                       create: (_) => SocietiesCubit(
                         authState.apiRepository,
                       )..load(),
-                      lazy: false,
+                      lazy: true,
                     )
                   ],
                   child: navigator,

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -16,6 +16,7 @@ class ListGroup {
   final DateTime? until;
   final String contactAddress;
   final Photo photo;
+
   bool isActiveBoard() =>
       type == MemberGroupType.board &&
       (until?.isAfter(DateTime.now()) ?? false);

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -16,7 +16,7 @@ class ListGroup {
   final DateTime? until;
   final String contactAddress;
   final Photo photo;
-  bool isActiveBoard () => type == MemberGroupType.board || (until?.isBefore(DateTime.now()) ?? false);
+  bool isActiveBoard () => type == MemberGroupType.board && (until?.isAfter(DateTime.now()) ?? false);
 
 
   const ListGroup(

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -16,6 +16,8 @@ class ListGroup {
   final DateTime? until;
   final String contactAddress;
   final Photo photo;
+  bool isActiveBoard () => type == MemberGroupType.board || (until?.isBefore(DateTime.now()) ?? false);
+
 
   const ListGroup(
     this.pk,

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -1,0 +1,52 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:reaxit/models/member.dart';
+import 'package:reaxit/models/photo.dart';
+
+part 'group.g.dart';
+
+enum MemberGroupType { committee, society, board }
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class ListGroup {
+  final int pk;
+  final String name;
+  final MemberGroupType type;
+  final String description;
+  final DateTime? since;
+  final DateTime? until;
+  final String contactAddress;
+  final Photo photo;
+
+  const ListGroup(
+    this.pk,
+    this.name,
+    this.type,
+    this.description,
+    this.since,
+    this.until,
+    this.contactAddress,
+    this.photo,
+  );
+
+  factory ListGroup.fromJson(Map<String, dynamic> json) =>
+      _$ListGroupFromJson(json);
+}
+
+@JsonSerializable(fieldRename: FieldRename.snake)
+class Group extends ListGroup {
+  final List<ListMember> members;
+
+  const Group(
+    int pk,
+    String name,
+    MemberGroupType type,
+    String description,
+    DateTime? since,
+    DateTime? until,
+    String contactAddress,
+    Photo photo,
+    this.members,
+  ) : super(pk, name, type, description, since, until, contactAddress, photo);
+
+  factory Group.fromJson(Map<String, dynamic> json) => _$GroupFromJson(json);
+}

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -16,8 +16,9 @@ class ListGroup {
   final DateTime? until;
   final String contactAddress;
   final Photo photo;
-  bool isActiveBoard () => type == MemberGroupType.board && (until?.isAfter(DateTime.now()) ?? false);
-
+  bool isActiveBoard() =>
+      type == MemberGroupType.board &&
+      (until?.isAfter(DateTime.now()) ?? false);
 
   const ListGroup(
     this.pk,

--- a/lib/models/group.g.dart
+++ b/lib/models/group.g.dart
@@ -1,0 +1,61 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'group.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ListGroup _$ListGroupFromJson(Map<String, dynamic> json) => ListGroup(
+      json['pk'] as int,
+      json['name'] as String,
+      $enumDecode(_$MemberGroupTypeEnumMap, json['type']),
+      json['description'] as String,
+      json['since'] == null ? null : DateTime.parse(json['since'] as String),
+      json['until'] == null ? null : DateTime.parse(json['until'] as String),
+      json['contact_address'] as String,
+      Photo.fromJson(json['photo'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$ListGroupToJson(ListGroup instance) => <String, dynamic>{
+      'pk': instance.pk,
+      'name': instance.name,
+      'type': _$MemberGroupTypeEnumMap[instance.type],
+      'description': instance.description,
+      'since': instance.since?.toIso8601String(),
+      'until': instance.until?.toIso8601String(),
+      'contact_address': instance.contactAddress,
+      'photo': instance.photo,
+    };
+
+const _$MemberGroupTypeEnumMap = {
+  MemberGroupType.committee: 'committee',
+  MemberGroupType.society: 'society',
+  MemberGroupType.board: 'board',
+};
+
+Group _$GroupFromJson(Map<String, dynamic> json) => Group(
+      json['pk'] as int,
+      json['name'] as String,
+      $enumDecode(_$MemberGroupTypeEnumMap, json['type']),
+      json['description'] as String,
+      json['since'] == null ? null : DateTime.parse(json['since'] as String),
+      json['until'] == null ? null : DateTime.parse(json['until'] as String),
+      json['contact_address'] as String,
+      Photo.fromJson(json['photo'] as Map<String, dynamic>),
+      (json['members'] as List<dynamic>)
+          .map((e) => ListMember.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$GroupToJson(Group instance) => <String, dynamic>{
+      'pk': instance.pk,
+      'name': instance.name,
+      'type': _$MemberGroupTypeEnumMap[instance.type],
+      'description': instance.description,
+      'since': instance.since?.toIso8601String(),
+      'until': instance.until?.toIso8601String(),
+      'contact_address': instance.contactAddress,
+      'photo': instance.photo,
+      'members': instance.members,
+    };

--- a/lib/models/group.g.dart
+++ b/lib/models/group.g.dart
@@ -44,7 +44,8 @@ Group _$GroupFromJson(Map<String, dynamic> json) => Group(
       json['contact_address'] as String,
       Photo.fromJson(json['photo'] as Map<String, dynamic>),
       (json['members'] as List<dynamic>)
-          .map((e) => ListMember.fromJson(e as Map<String, dynamic>))
+          .map(
+              (e) => ListMember.fromJson((e as Map<String, dynamic>)["member"]))
           .toList(),
     );
 

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -13,6 +13,7 @@ import 'package:reaxit/ui/screens/event_screen.dart';
 import 'package:reaxit/ui/screens/food_admin_screen.dart';
 import 'package:reaxit/ui/screens/food_screen.dart';
 import 'package:reaxit/ui/screens/login_screen.dart';
+import 'package:reaxit/ui/screens/groups_screen.dart';
 import 'package:reaxit/ui/screens/members_screen.dart';
 import 'package:reaxit/ui/screens/profile_screen.dart';
 import 'package:reaxit/ui/screens/registration_screen.dart';
@@ -213,4 +214,11 @@ final List<GoRoute> routes = [
       child: const LoginScreen(),
     ),
   ),
+  GoRoute(
+      path: '/groups',
+      name: 'groups',
+      pageBuilder: (context, state) => MaterialPage(
+            key: state.pageKey,
+            child: GroupsScreen(), //TODO: make url arguments work
+          ))
 ];

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -252,51 +252,54 @@ final List<GoRoute> routes = [
     path: '/committees',
     name: 'committees',
     pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const GroupsScreen(
-          startScreen: MemberGroupType.committee,
-        )),
+      key: state.pageKey,
+      child: const GroupsScreen(startScreen: MemberGroupType.committee),
+    ),
     routes: [
       GoRoute(
-          path: ':committeePk',
-          name: 'committee',
-          pageBuilder: (context, state) => MaterialPage(
-              key: state.pageKey,
-              child: GroupScreen(pk: int.parse(state.params['committeePk']!))))
+        path: ':committeePk',
+        name: 'committee',
+        pageBuilder: (context, state) => MaterialPage(
+          key: state.pageKey,
+          child: GroupScreen(pk: int.parse(state.params['committeePk']!)),
+        ),
+      )
     ],
   ),
   GoRoute(
     path: '/societies',
     name: 'societies',
     pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const GroupsScreen(
-          startScreen: MemberGroupType.society,
-        )),
+      key: state.pageKey,
+      child: const GroupsScreen(startScreen: MemberGroupType.society),
+    ),
     routes: [
       GoRoute(
-          path: ':societyPk',
-          name: 'society',
-          pageBuilder: (context, state) => MaterialPage(
-              key: state.pageKey,
-              child: GroupScreen(pk: int.parse(state.params['societyPk']!))))
+        path: ':societyPk',
+        name: 'society',
+        pageBuilder: (context, state) => MaterialPage(
+          key: state.pageKey,
+          child: GroupScreen(pk: int.parse(state.params['societyPk']!)),
+        ),
+      )
     ],
   ),
   GoRoute(
     path: '/boards',
     name: 'boards',
     pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const GroupsScreen(
-          startScreen: MemberGroupType.board,
-        )),
+      key: state.pageKey,
+      child: const GroupsScreen(startScreen: MemberGroupType.board),
+    ),
     routes: [
       GoRoute(
-          path: ':boardPk',
-          name: 'board',
-          pageBuilder: (context, state) => MaterialPage(
-              key: state.pageKey,
-              child: GroupScreen(pk: int.parse(state.params['boardPk']!))))
+        path: ':boardPk',
+        name: 'board',
+        pageBuilder: (context, state) => MaterialPage(
+          key: state.pageKey,
+          child: GroupScreen(pk: int.parse(state.params['boardPk']!)),
+        ),
+      )
     ],
   )
 ];

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -4,6 +4,7 @@ import 'package:reaxit/config.dart' as config;
 import 'package:reaxit/models/album.dart';
 import 'package:reaxit/models/event.dart';
 import 'package:reaxit/models/event_registration.dart';
+import 'package:reaxit/models/group.dart';
 import 'package:reaxit/models/member.dart';
 import 'package:reaxit/ui/screens/album_screen.dart';
 import 'package:reaxit/ui/screens/albums_screen.dart';
@@ -12,6 +13,7 @@ import 'package:reaxit/ui/screens/event_admin_screen.dart';
 import 'package:reaxit/ui/screens/event_screen.dart';
 import 'package:reaxit/ui/screens/food_admin_screen.dart';
 import 'package:reaxit/ui/screens/food_screen.dart';
+import 'package:reaxit/ui/screens/group_screen.dart';
 import 'package:reaxit/ui/screens/login_screen.dart';
 import 'package:reaxit/ui/screens/groups_screen.dart';
 import 'package:reaxit/ui/screens/members_screen.dart';
@@ -215,10 +217,86 @@ final List<GoRoute> routes = [
     ),
   ),
   GoRoute(
-      path: '/groups',
-      name: 'groups',
-      pageBuilder: (context, state) => MaterialPage(
-            key: state.pageKey,
-            child: GroupsScreen(), //TODO: make url arguments work
-          ))
+    path: '/association/committees/:groupSlug',
+    redirect: (state) => '/committees/${state.params['groupSlug']}',
+  ),
+  GoRoute(
+    path: '/association/societies/:groupSlug',
+    redirect: (state) => '/societies/${state.params['groupSlug']}',
+  ),
+  GoRoute(
+    path: '/association/boards/:groupSlug',
+    redirect: (state) => '/boards/${state.params['groupSlug']}',
+  ),
+  GoRoute(
+    path: '/association/committees',
+    redirect: (state) => '/committees',
+  ),
+  GoRoute(
+    path: '/association/societies',
+    redirect: (state) => '/societies',
+  ),
+  GoRoute(
+    path: '/association/boards',
+    redirect: (state) => '/boards',
+  ),
+  GoRoute(
+    path: '/groups',
+    name: 'groups',
+    pageBuilder: (context, state) => MaterialPage(
+      key: state.pageKey,
+      child: const GroupsScreen(),
+    ),
+  ),
+  GoRoute(
+    path: '/committees',
+    name: 'committees',
+    pageBuilder: (context, state) => MaterialPage(
+        key: state.pageKey,
+        child: const GroupsScreen(
+          startScreen: MemberGroupType.committee,
+        )),
+    routes: [
+      GoRoute(
+          path: ':committeePk',
+          name: 'committee',
+          pageBuilder: (context, state) => MaterialPage(
+              key: state.pageKey,
+              child: GroupScreen(pk: int.parse(state.params['committeePk']!))))
+    ],
+  ),
+  GoRoute(
+    path: '/societies',
+    name: 'societies',
+    pageBuilder: (context, state) => MaterialPage(
+        key: state.pageKey,
+        child: const GroupsScreen(
+          startScreen: MemberGroupType.society,
+        )),
+    routes: [
+      GoRoute(
+          path: ':societyPk',
+          name: 'society',
+          pageBuilder: (context, state) => MaterialPage(
+              key: state.pageKey,
+              child: GroupScreen(pk: int.parse(state.params['societyPk']!))))
+    ],
+  ),
+  GoRoute(
+    path: '/boards',
+    name: 'boards',
+    pageBuilder: (context, state) => MaterialPage(
+        key: state.pageKey,
+        child: const GroupsScreen(
+          startScreen: MemberGroupType.board,
+        )),
+    routes: [
+      GoRoute(
+          path: ':boardPk',
+          name: 'board',
+          pageBuilder: (context, state) => MaterialPage(
+              key: state.pageKey,
+              child: GroupScreen(pk: int.parse(state.params['boardPk']!))))
+    ],
+  )
 ];

--- a/lib/ui/screens/group_screen.dart
+++ b/lib/ui/screens/group_screen.dart
@@ -47,7 +47,7 @@ class _GroupScreenState extends State<GroupScreen> {
       children: [
         CachedImage(
             imageUrl: group.photo.full,
-            placeholder: 'assets/img/default-avatag.jpg')
+            placeholder: 'assets/img/default-avatar.jpg')
       ],
     );
   }

--- a/lib/ui/screens/group_screen.dart
+++ b/lib/ui/screens/group_screen.dart
@@ -1,0 +1,224 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
+import 'package:reaxit/api/api_repository.dart';
+import 'package:reaxit/blocs/group_cubit.dart';
+import 'package:reaxit/blocs/member_list_cubit.dart';
+import 'package:reaxit/models/group.dart';
+import 'package:reaxit/models/member.dart';
+import 'package:reaxit/ui/widgets/cached_image.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../widgets/app_bar.dart';
+import '../widgets/error_scroll_view.dart';
+import '../widgets/member_tile.dart';
+
+class GroupScreen extends StatefulWidget {
+  final int pk;
+  final Group? group;
+
+  GroupScreen({required this.pk, this.group}) : super(key: ValueKey(pk));
+
+  @override
+  State createState() => _GroupScreenState();
+}
+
+class _GroupScreenState extends State<GroupScreen> {
+  late ScrollController _controller;
+
+  late final GroupCubit _groupCubit;
+
+  @override
+  void initState() {
+    final api = RepositoryProvider.of<ApiRepository>(context);
+    _groupCubit = GroupCubit(api, pk: widget.pk)..load();
+    _controller = ScrollController(); //..addListener(_scrollListener());
+    super.initState();
+  }
+
+  void _scrollListener() {
+    if (_controller.position.pixels >=
+        _controller.position.maxScrollExtent - 300) {
+      // Only request loading more if that's not already happening.
+      // if (!_registrationsCubit.state.isLoadingMore) {
+      //   _registrationsCubit.more();
+      // }
+    }
+  }
+
+  @override
+  void dispose() {
+    _groupCubit.close();
+    super.dispose();
+  }
+
+  Widget _makeImage(ListGroup group) {
+    return Stack(
+      fit: StackFit.loose,
+      children: [
+        CachedImage(
+            imageUrl: group.photo.full,
+            placeholder: 'assets/img/default-avatag.jpg')
+      ],
+    );
+  }
+
+  Widget _makeDescription(ListGroup group) {
+    return Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 0, vertical: 4),
+        child: HtmlWidget(
+          group.description,
+          onTapUrl: (String url) async {
+            try {
+              await launch(
+                url,
+                forceSafariVC: false,
+                forceWebView: false,
+              );
+            } catch (_) {
+              ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                behavior: SnackBarBehavior.floating,
+                content: Text('Could not open "$url".'),
+              ));
+            }
+            return true;
+          },
+        ));
+  }
+
+  Widget _makeDescriptionHeader(ListGroup group) {
+    return SliverPadding(
+      padding: const EdgeInsets.only(left: 16),
+      sliver: SliverToBoxAdapter(
+        child: Text(
+          'DESCRIPTION',
+          style: Theme.of(context).textTheme.caption,
+        ),
+      ),
+    );
+  }
+
+  Widget _makeMembersHeader(ListGroup group) {
+    return SliverPadding(
+      padding: const EdgeInsets.only(left: 16),
+      sliver: SliverToBoxAdapter(
+        child: Text(
+          'MEMBERS',
+          style: Theme.of(context).textTheme.caption,
+        ),
+      ),
+    );
+  }
+
+  SliverPadding _makeMembers(List<ListMember> members) {
+    if (members.isEmpty) {
+      return const SliverPadding(
+        padding: EdgeInsets.only(left: 16, right: 16, top: 8, bottom: 16),
+        sliver: SliverToBoxAdapter(
+            child: Center(child: Text('This group has no members.'))),
+      );
+    } else {
+      return SliverPadding(
+        padding: const EdgeInsets.only(left: 16, right: 16, top: 8, bottom: 16),
+        sliver: SliverGrid(
+          gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 3,
+            mainAxisSpacing: 8,
+            crossAxisSpacing: 8,
+          ),
+          delegate: SliverChildBuilderDelegate(
+            (context, index) {
+              return MemberTile(
+                member: members[index],
+              );
+            },
+            childCount: members.length,
+          ),
+        ),
+      );
+    }
+  }
+
+  Widget _makeGroupInfo(Group group) {
+    final textTheme = Theme.of(context).textTheme;
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          const SizedBox(height: 8),
+          Text(
+            group.name.toUpperCase(),
+            style: textTheme.headline6,
+          ),
+          const Divider(height: 24),
+          _makeDescription(group),
+          const Divider(height: 24),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<GroupCubit, GroupState>(
+        bloc: _groupCubit,
+        builder: (context, state) {
+          if (state.hasException) {
+            return Scaffold(
+              appBar: ThaliaAppBar(
+                title: Text(widget.group?.name.toUpperCase() ?? 'GROUP'),
+              ),
+              body: RefreshIndicator(
+                onRefresh: () async {
+                  // Await the load.
+                  await _groupCubit.load();
+                },
+                child: ErrorScrollView(state.message!),
+              ),
+            );
+          } else if (state.isLoading &&
+              widget.group == null &&
+              state.result == null) {
+            return Scaffold(
+              appBar: ThaliaAppBar(
+                title: const Text('GROUP'),
+              ),
+              body: const Center(child: CircularProgressIndicator()),
+            );
+          } else {
+            final group = (state.result ?? widget.group)!;
+            return Scaffold(
+              appBar: ThaliaAppBar(title: Text(group.name.toUpperCase())),
+              body: RefreshIndicator(
+                  onRefresh: () => _groupCubit.load(),
+                  child: Scrollbar(
+                    controller: _controller,
+                    child: CustomScrollView(
+                      controller: _controller,
+                      key: const PageStorageKey('event'),
+                      slivers: [
+                        SliverToBoxAdapter(
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.stretch,
+                            children: [
+                              _makeImage(group),
+                              const Divider(height: 0),
+                              _makeGroupInfo(group)
+                              //const Divider(),
+                              //_makeMembers(group.members)
+                            ],
+                          ),
+                        ),
+                        //_makeDescriptionHeader(group),
+                        //const SliverToBoxAdapter(child: Divider()),
+                        _makeMembersHeader(group),
+                        _makeMembers(group.members)
+                      ],
+                    ),
+                  )),
+            );
+          }
+        });
+  }
+}

--- a/lib/ui/screens/group_screen.dart
+++ b/lib/ui/screens/group_screen.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_widget_from_html_core/flutter_widget_from_html_core.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/blocs/group_cubit.dart';
-import 'package:reaxit/blocs/member_list_cubit.dart';
 import 'package:reaxit/models/group.dart';
 import 'package:reaxit/models/member.dart';
 import 'package:reaxit/ui/widgets/cached_image.dart';
@@ -34,16 +33,6 @@ class _GroupScreenState extends State<GroupScreen> {
     _groupCubit = GroupCubit(api, pk: widget.pk)..load();
     _controller = ScrollController(); //..addListener(_scrollListener());
     super.initState();
-  }
-
-  void _scrollListener() {
-    if (_controller.position.pixels >=
-        _controller.position.maxScrollExtent - 300) {
-      // Only request loading more if that's not already happening.
-      // if (!_registrationsCubit.state.isLoadingMore) {
-      //   _registrationsCubit.more();
-      // }
-    }
   }
 
   @override
@@ -84,18 +73,6 @@ class _GroupScreenState extends State<GroupScreen> {
             return true;
           },
         ));
-  }
-
-  Widget _makeDescriptionHeader(ListGroup group) {
-    return SliverPadding(
-      padding: const EdgeInsets.only(left: 16),
-      sliver: SliverToBoxAdapter(
-        child: Text(
-          'DESCRIPTION',
-          style: Theme.of(context).textTheme.caption,
-        ),
-      ),
-    );
   }
 
   Widget _makeMembersHeader(ListGroup group) {

--- a/lib/ui/screens/group_screen.dart
+++ b/lib/ui/screens/group_screen.dart
@@ -9,10 +9,10 @@ import 'package:reaxit/models/member.dart';
 import 'package:reaxit/ui/widgets/cached_image.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../../routes.dart';
-import '../widgets/app_bar.dart';
-import '../widgets/error_scroll_view.dart';
-import '../widgets/member_tile.dart';
+import 'package:reaxit/routes.dart';
+import 'package:reaxit/ui/widgets/app_bar.dart';
+import 'package:reaxit/ui/widgets/error_scroll_view.dart';
+import 'package:reaxit/ui/widgets/member_tile.dart';
 
 class GroupScreen extends StatefulWidget {
   final int pk;
@@ -45,8 +45,9 @@ class _GroupScreenState extends State<GroupScreen> {
       fit: StackFit.loose,
       children: [
         CachedImage(
-            imageUrl: group.photo.full,
-            placeholder: 'assets/img/default-avatar.jpg')
+          imageUrl: group.photo.full,
+          placeholder: 'assets/img/default-avatar.jpg',
+        )
       ],
     );
   }
@@ -101,9 +102,8 @@ class _GroupScreenState extends State<GroupScreen> {
       return const SliverPadding(
         padding: EdgeInsets.only(left: 16, right: 16, top: 8, bottom: 16),
         sliver: SliverToBoxAdapter(
-            child: Center(
-          child: Text('This group has no members.'),
-        )),
+          child: Center(child: Text('This group has no members.')),
+        ),
       );
     } else {
       return SliverPadding(
@@ -150,61 +150,54 @@ class _GroupScreenState extends State<GroupScreen> {
   @override
   Widget build(BuildContext context) {
     return BlocBuilder<GroupCubit, GroupState>(
-        bloc: _groupCubit,
-        builder: (context, state) {
-          if (state.hasException) {
-            return Scaffold(
-              appBar: ThaliaAppBar(
-                title: Text(widget.group?.name.toUpperCase() ?? 'GROUP'),
-              ),
-              body: RefreshIndicator(
-                onRefresh: () async {
-                  // Await the load.
-                  await _groupCubit.load();
-                },
-                child: ErrorScrollView(state.message!),
-              ),
-            );
-          } else if (state.isLoading &&
-              widget.group == null &&
-              state.result == null) {
-            return Scaffold(
-              appBar: ThaliaAppBar(
-                title: const Text('GROUP'),
-              ),
-              body: const Center(child: CircularProgressIndicator()),
-            );
-          } else {
-            final group = (state.result ?? widget.group)!;
-            return Scaffold(
-              appBar: ThaliaAppBar(title: Text(group.name.toUpperCase())),
-              body: RefreshIndicator(
-                  onRefresh: () => _groupCubit.load(),
-                  child: Scrollbar(
-                    child: CustomScrollView(
-                      key: const PageStorageKey('event'),
-                      slivers: [
-                        SliverToBoxAdapter(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [
-                              _makeImage(group),
-                              const Divider(height: 0),
-                              _makeGroupInfo(group)
-                              //const Divider(),
-                              //_makeMembers(group.members)
-                            ],
-                          ),
-                        ),
-                        //_makeDescriptionHeader(group),
-                        //const SliverToBoxAdapter(child: Divider()),
-                        _makeMembersHeader(group),
-                        _makeMembers(group.members),
-                      ],
+      bloc: _groupCubit,
+      builder: (context, state) {
+        if (state.hasException) {
+          return Scaffold(
+            appBar: ThaliaAppBar(
+              title: Text(widget.group?.name.toUpperCase() ?? 'GROUP'),
+            ),
+            body: RefreshIndicator(
+              onRefresh: () => _groupCubit.load(),
+              child: ErrorScrollView(state.message!),
+            ),
+          );
+        } else if (state.isLoading &&
+            widget.group == null &&
+            state.result == null) {
+          return Scaffold(
+            appBar: ThaliaAppBar(title: const Text('GROUP')),
+            body: const Center(child: CircularProgressIndicator()),
+          );
+        } else {
+          final group = (state.result ?? widget.group)!;
+          return Scaffold(
+            appBar: ThaliaAppBar(title: Text(group.name.toUpperCase())),
+            body: RefreshIndicator(
+              onRefresh: () => _groupCubit.load(),
+              child: Scrollbar(
+                child: CustomScrollView(
+                  key: const PageStorageKey('group'),
+                  slivers: [
+                    SliverToBoxAdapter(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.stretch,
+                        children: [
+                          _makeImage(group),
+                          const Divider(height: 0),
+                          _makeGroupInfo(group)
+                        ],
+                      ),
                     ),
-                  )),
-            );
-          }
-        });
+                    _makeMembersHeader(group),
+                    _makeMembers(group.members),
+                  ],
+                ),
+              ),
+            ),
+          );
+        }
+      },
+    );
   }
 }

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -12,6 +12,10 @@ import 'package:reaxit/ui/widgets/menu_drawer.dart';
 import 'package:collection/collection.dart';
 
 class GroupsScreen extends StatefulWidget {
+  final MemberGroupType? startScreen;
+
+  const GroupsScreen({this.startScreen});
+
   @override
   State<StatefulWidget> createState() => _GroupsScreenState();
 }
@@ -23,6 +27,29 @@ class _GroupsScreenState extends State<GroupsScreen>
   @override
   void initState() {
     _tabController = TabController(length: 3, vsync: this);
+    switch (widget.startScreen) {
+      case MemberGroupType.committee:
+        _tabController.animateTo(
+          0,
+          duration: Duration.zero,
+        );
+        break;
+      case MemberGroupType.society:
+        _tabController.animateTo(
+          1,
+          duration: Duration.zero,
+        );
+        break;
+      case MemberGroupType.board:
+        _tabController.animateTo(
+          2,
+          duration: Duration.zero,
+        );
+        break;
+      default:
+        break;
+    }
+
     super.initState();
   }
 
@@ -134,9 +161,6 @@ class GroupListScrollView extends StatelessWidget {
                   child: AspectRatio(
                       aspectRatio: 3 / 2,
                       child: GroupTile(group: activeBoard!)))),
-
-        //  SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: GroupTile(group: activeBoard))),
-        //  SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: GroupTile(group: activeBoard))),
         SliverPadding(
           padding: const EdgeInsets.all(8),
           sliver: SliverGrid(

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -26,29 +26,22 @@ class _GroupsScreenState extends State<GroupsScreen>
 
   @override
   void initState() {
-    _tabController = TabController(length: 3, vsync: this);
-    switch (widget.startScreen) {
-      case MemberGroupType.committee:
-        _tabController.animateTo(
-          0,
-          duration: Duration.zero,
-        );
-        break;
-      case MemberGroupType.society:
-        _tabController.animateTo(
-          1,
-          duration: Duration.zero,
-        );
-        break;
-      case MemberGroupType.board:
-        _tabController.animateTo(
-          2,
-          duration: Duration.zero,
-        );
-        break;
-      default:
-        break;
+    late final int initialIndex;
+    if (widget.startScreen == MemberGroupType.board) {
+      initialIndex = 0;
+    } else if (widget.startScreen == MemberGroupType.committee) {
+      initialIndex = 1;
+    } else if (widget.startScreen == MemberGroupType.society) {
+      initialIndex = 2;
+    } else {
+      initialIndex = 0;
     }
+
+    _tabController = TabController(
+      length: 3,
+      initialIndex: initialIndex,
+      vsync: this,
+    );
 
     super.initState();
   }
@@ -77,13 +70,9 @@ class _GroupsScreenState extends State<GroupsScreen>
               if (state.hasException) {
                 return ErrorScrollView(state.message!);
               } else if (state.isLoading) {
-                return const SliverPadding(
+                return const Padding(
                   padding: EdgeInsets.all(16),
-                  sliver: SliverToBoxAdapter(
-                    child: Center(
-                      child: CircularProgressIndicator(),
-                    ),
-                  ),
+                  child: Center(child: CircularProgressIndicator()),
                 );
               } else {
                 return GroupListScrollView(groups: state.result!);
@@ -95,13 +84,9 @@ class _GroupsScreenState extends State<GroupsScreen>
               if (state.hasException) {
                 return ErrorScrollView(state.message!);
               } else if (state.isLoading) {
-                return const SliverPadding(
+                return const Padding(
                   padding: EdgeInsets.all(16),
-                  sliver: SliverToBoxAdapter(
-                    child: Center(
-                      child: CircularProgressIndicator(),
-                    ),
-                  ),
+                  child: Center(child: CircularProgressIndicator()),
                 );
               } else {
                 return GroupListScrollView(groups: state.result!);
@@ -113,13 +98,9 @@ class _GroupsScreenState extends State<GroupsScreen>
               if (state.hasException) {
                 return ErrorScrollView(state.message!);
               } else if (state.isLoading) {
-                return const SliverPadding(
+                return const Padding(
                   padding: EdgeInsets.all(16),
-                  sliver: SliverToBoxAdapter(
-                    child: Center(
-                      child: CircularProgressIndicator(),
-                    ),
-                  ),
+                  child: Center(child: CircularProgressIndicator()),
                 );
               } else {
                 return GroupListScrollView(groups: state.result!);
@@ -137,8 +118,9 @@ class GroupListScrollView extends StatelessWidget {
   final ListGroup? activeBoard;
 
   GroupListScrollView({Key? key, required List<ListGroup> groups})
-      : activeBoard =
-            groups.firstWhereOrNull((element) => element.isActiveBoard()),
+      : activeBoard = groups.firstWhereOrNull(
+          (element) => element.isActiveBoard(),
+        ),
         groups = groups
             .where((element) => !element.isActiveBoard())
             .toList()
@@ -149,35 +131,37 @@ class GroupListScrollView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scrollbar(
-        child: CustomScrollView(
-      physics: const RangeMaintainingScrollPhysics(
-        parent: AlwaysScrollableScrollPhysics(),
-      ),
-      slivers: [
-        if (activeBoard != null)
-          SliverToBoxAdapter(
+      child: CustomScrollView(
+        physics: const RangeMaintainingScrollPhysics(
+          parent: AlwaysScrollableScrollPhysics(),
+        ),
+        slivers: [
+          if (activeBoard != null)
+            SliverToBoxAdapter(
               child: Padding(
-                  padding: const EdgeInsets.all(8),
-                  child: AspectRatio(
-                      aspectRatio: 3 / 2,
-                      child: GroupTile(group: activeBoard!)))),
-        SliverPadding(
-          padding: const EdgeInsets.all(8),
-          sliver: SliverGrid(
-            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-              crossAxisCount: 3,
-              mainAxisSpacing: 8,
-              crossAxisSpacing: 8,
-            ),
-            delegate: SliverChildBuilderDelegate(
-              (context, index) => GroupTile(
-                group: groups[index],
+                padding: const EdgeInsets.all(8),
+                child: AspectRatio(
+                  aspectRatio: 3 / 2,
+                  child: GroupTile(group: activeBoard!),
+                ),
               ),
-              childCount: groups.length,
+            ),
+          SliverPadding(
+            padding: const EdgeInsets.all(8),
+            sliver: SliverGrid(
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                mainAxisSpacing: 8,
+                crossAxisSpacing: 8,
+              ),
+              delegate: SliverChildBuilderDelegate(
+                (context, index) => GroupTile(group: groups[index]),
+                childCount: groups.length,
+              ),
             ),
           ),
-        ),
-      ],
-    ));
+        ],
+      ),
+    );
   }
 }

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reaxit/blocs/detail_state.dart';
+import 'package:reaxit/blocs/boards_cubit.dart';
+import 'package:reaxit/blocs/committees_cubit.dart';
+import 'package:reaxit/blocs/societies_cubit.dart';
+import 'package:reaxit/models/group.dart';
+import 'package:reaxit/ui/widgets/app_bar.dart';
+import 'package:reaxit/ui/widgets/error_scroll_view.dart';
+import 'package:reaxit/ui/widgets/group_tile.dart';
+import 'package:reaxit/ui/widgets/menu_drawer.dart';
+
+class GroupsScreen extends StatefulWidget {
+  @override
+  State<StatefulWidget> createState() => _GroupsScreenState();
+}
+
+class _GroupsScreenState extends State<GroupsScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    _tabController = TabController(length: 3, vsync: this);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: ThaliaAppBar(
+        title: const Text('GROUPS'),
+        actions: [
+          IconButton(
+            padding: const EdgeInsets.all(16),
+            icon: const Icon(Icons.search),
+            onPressed: () async {
+              //TODO: Implement group search
+            },
+          ),
+        ],
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'Committees'),
+            Tab(text: 'Societies'),
+            Tab(text: 'Boards'),
+          ],
+          indicatorColor: Theme.of(context).colorScheme.primary,
+        ),
+      ),
+      drawer: MenuDrawer(),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          BlocBuilder<CommitteesCubit, DetailState<List<ListGroup>>>(
+            builder: (context, state) {
+              if (state.hasException) {
+                return ErrorScrollView(state.message!);
+              } else if (state.isLoading) {
+                return const SliverPadding(
+                  padding: EdgeInsets.all(16),
+                  sliver: SliverToBoxAdapter(
+                    child: Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+                );
+              } else {
+                return GroupListScrollView(groups: state.result!);
+              }
+            },
+          ),
+          BlocBuilder<SocietiesCubit, DetailState<List<ListGroup>>>(
+            builder: (context, state) {
+              if (state.hasException) {
+                return ErrorScrollView(state.message!);
+              } else if (state.isLoading) {
+                return const SliverPadding(
+                  padding: EdgeInsets.all(16),
+                  sliver: SliverToBoxAdapter(
+                    child: Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+                );
+              } else {
+                return GroupListScrollView(groups: state.result!);
+              }
+            },
+          ),
+          BlocBuilder<BoardsCubit, DetailState<List<ListGroup>>>(
+            builder: (context, state) {
+              if (state.hasException) {
+                return ErrorScrollView(state.message!);
+              } else if (state.isLoading) {
+                return const SliverPadding(
+                  padding: EdgeInsets.all(16),
+                  sliver: SliverToBoxAdapter(
+                    child: Center(
+                      child: CircularProgressIndicator(),
+                    ),
+                  ),
+                );
+              } else {
+                return GroupListScrollView(groups: state.result!);
+              }
+            },
+          )
+        ],
+      ),
+    );
+  }
+}
+
+class GroupListScrollView extends StatelessWidget {
+  final List<ListGroup> groups;
+
+  const GroupListScrollView({Key? key, required this.groups}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scrollbar(
+        child: CustomScrollView(
+      physics: const RangeMaintainingScrollPhysics(
+        parent: AlwaysScrollableScrollPhysics(),
+      ),
+      slivers: [
+        SliverPadding(
+          padding: const EdgeInsets.all(8),
+          sliver: SliverGrid(
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 3,
+              mainAxisSpacing: 8,
+              crossAxisSpacing: 8,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) => GroupTile(
+                group: groups[index],
+              ),
+              childCount: groups.length,
+            ),
+          ),
+        ),
+      ],
+    ));
+  }
+}

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -10,6 +10,7 @@ import 'package:reaxit/ui/widgets/app_bar.dart';
 import 'package:reaxit/ui/widgets/error_scroll_view.dart';
 import 'package:reaxit/ui/widgets/group_tile.dart';
 import 'package:reaxit/ui/widgets/menu_drawer.dart';
+import 'package:collection/collection.dart';
 
 class GroupsScreen extends StatefulWidget {
   @override
@@ -121,12 +122,22 @@ class GroupListScrollView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+
+    ListGroup? activeBoard;
+    activeBoard = groups.firstWhereOrNull((element) => element.isActiveBoard());
+    groups.remove(activeBoard);
+
     return Scrollbar(
         child: CustomScrollView(
       physics: const RangeMaintainingScrollPhysics(
         parent: AlwaysScrollableScrollPhysics(),
       ),
       slivers: [
+        if (activeBoard != null)
+          SliverPadding(
+          padding: const EdgeInsets.all(8),
+          sliver: SliverToBoxAdapter(child: GroupTile(group: activeBoard)),
+        ),
         SliverPadding(
           padding: const EdgeInsets.all(8),
           sliver: SliverGrid(

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -119,14 +119,18 @@ class GroupListScrollView extends StatelessWidget {
   final List<ListGroup> groups;
   final ListGroup? activeBoard;
 
-  GroupListScrollView({Key? key, required List<ListGroup> groups}) :
-    activeBoard = groups.firstWhereOrNull((element) => element.isActiveBoard()),
-        groups = groups.where((element) => ! element.isActiveBoard()).toList().reversed.toList(), super(key: key);
-
+  GroupListScrollView({Key? key, required List<ListGroup> groups})
+      : activeBoard =
+            groups.firstWhereOrNull((element) => element.isActiveBoard()),
+        groups = groups
+            .where((element) => !element.isActiveBoard())
+            .toList()
+            .reversed
+            .toList(),
+        super(key: key);
 
   @override
   Widget build(BuildContext context) {
-
     return Scrollbar(
         child: CustomScrollView(
       physics: const RangeMaintainingScrollPhysics(
@@ -134,9 +138,14 @@ class GroupListScrollView extends StatelessWidget {
       ),
       slivers: [
         if (activeBoard != null)
-          SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: AspectRatio(aspectRatio: 3/2,child:GroupTile(group: activeBoard!)))),
+          SliverToBoxAdapter(
+              child: Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: AspectRatio(
+                      aspectRatio: 3 / 2,
+                      child: GroupTile(group: activeBoard!)))),
 
-          //  SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: GroupTile(group: activeBoard))),
+        //  SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: GroupTile(group: activeBoard))),
         //  SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: GroupTile(group: activeBoard))),
         SliverPadding(
           padding: const EdgeInsets.all(8),

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/blocs/detail_state.dart';

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -117,15 +117,15 @@ class _GroupsScreenState extends State<GroupsScreen>
 
 class GroupListScrollView extends StatelessWidget {
   final List<ListGroup> groups;
+  final ListGroup? activeBoard;
 
-  const GroupListScrollView({Key? key, required this.groups}) : super(key: key);
+  GroupListScrollView({Key? key, required List<ListGroup> groups}) :
+    activeBoard = groups.firstWhereOrNull((element) => element.isActiveBoard()),
+        groups = groups.where((element) => ! element.isActiveBoard()).toList().reversed.toList(), super(key: key);
+
 
   @override
   Widget build(BuildContext context) {
-
-    ListGroup? activeBoard;
-    activeBoard = groups.firstWhereOrNull((element) => element.isActiveBoard());
-    groups.remove(activeBoard);
 
     return Scrollbar(
         child: CustomScrollView(
@@ -134,10 +134,10 @@ class GroupListScrollView extends StatelessWidget {
       ),
       slivers: [
         if (activeBoard != null)
-          SliverPadding(
-          padding: const EdgeInsets.all(8),
-          sliver: SliverToBoxAdapter(child: GroupTile(group: activeBoard)),
-        ),
+          SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: AspectRatio(aspectRatio: 3/2,child:GroupTile(group: activeBoard!)))),
+
+          //  SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: GroupTile(group: activeBoard))),
+        //  SliverToBoxAdapter(child: Padding(padding: const EdgeInsets.all(8), child: GroupTile(group: activeBoard))),
         SliverPadding(
           padding: const EdgeInsets.all(8),
           sliver: SliverGrid(

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -31,15 +31,6 @@ class _GroupsScreenState extends State<GroupsScreen>
     return Scaffold(
       appBar: ThaliaAppBar(
         title: const Text('GROUPS'),
-        actions: [
-          IconButton(
-            padding: const EdgeInsets.all(16),
-            icon: const Icon(Icons.search),
-            onPressed: () async {
-              //TODO: Implement group search
-            },
-          ),
-        ],
         bottom: TabBar(
           controller: _tabController,
           tabs: const [

--- a/lib/ui/widgets/app_bar.dart
+++ b/lib/ui/widgets/app_bar.dart
@@ -6,6 +6,7 @@ class ThaliaAppBar extends AppBar {
     Widget? title,
     List<Widget>? actions,
     Widget? leading,
+    PreferredSizeWidget? bottom,
   }) : super(
           title: title,
           actions: actions,
@@ -14,15 +15,16 @@ class ThaliaAppBar extends AppBar {
           // The bottom decoration only needs to be shown
           // in dark mode, but is invisible in light mode,
           // so we can just leave it there.
-          bottom: PreferredSize(
-            preferredSize: const Size.fromHeight(0),
-            child: Container(
-              decoration: const BoxDecoration(
-                border: Border(
-                  bottom: BorderSide(color: Color(0xFFE62272)),
+          bottom: bottom ??
+              PreferredSize(
+                preferredSize: const Size.fromHeight(0),
+                child: Container(
+                  decoration: const BoxDecoration(
+                    border: Border(
+                      bottom: BorderSide(color: Color(0xFFE62272)),
+                    ),
+                  ),
                 ),
               ),
-            ),
-          ),
         );
 }

--- a/lib/ui/widgets/group_tile.dart
+++ b/lib/ui/widgets/group_tile.dart
@@ -1,0 +1,119 @@
+import 'package:animations/animations.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:reaxit/models/group.dart';
+import 'package:reaxit/ui/screens/groups_screen.dart';
+
+import 'cached_image.dart';
+
+class GroupTile extends StatelessWidget {
+  final ListGroup group;
+
+  const GroupTile({Key? key, required this.group}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return OpenContainer(
+      tappable: false,
+      routeSettings: RouteSettings(name: 'Group(${group.pk})'),
+      transitionType: ContainerTransitionType.fadeThrough,
+      closedShape: const RoundedRectangleBorder(),
+      closedBuilder: (context, openContainer) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            CachedImage(
+              imageUrl: group.photo.small,
+              placeholder: 'assets/img/default-avatar.jpg',
+            ),
+            const _BlackGradient(),
+            Align(
+              alignment: Alignment.bottomLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  group.name,
+                  style: Theme.of(context).primaryTextTheme.bodyText2,
+                ),
+              ),
+            ),
+            Positioned.fill(
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(onTap: openContainer),
+              ),
+            ),
+          ],
+        );
+      },
+      //TODO: GroupScreen
+      openBuilder: (_, __) => GroupsScreen(),
+      //openBuilder: (_, __) => ProfileScreen(pk: member.pk, member: member),
+    );
+  }
+}
+
+class _BlackGradient extends StatelessWidget {
+  static const _black00 = Color(0x00000000);
+  static const _black50 = Color(0x80000000);
+
+  const _BlackGradient();
+
+  @override
+  Widget build(BuildContext context) {
+    return const DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.black,
+        gradient: LinearGradient(
+          begin: FractionalOffset.topCenter,
+          end: FractionalOffset.bottomCenter,
+          colors: [_black00, _black50],
+          stops: [0.4, 1.0],
+        ),
+      ),
+    );
+  }
+}
+
+/// A replacement for [MemberTile] for when the person is not actually a member.
+class DefaultMemberTile extends StatelessWidget {
+  final String name;
+
+  const DefaultMemberTile({Key? key, required this.name}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        Image.asset('assets/img/default-avatar.jpg'),
+        const _BlackGradient(),
+        Align(
+          alignment: Alignment.bottomLeft,
+          child: Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: Text(
+              name,
+              style: Theme.of(context).primaryTextTheme.bodyText2,
+            ),
+          ),
+        ),
+        Positioned.fill(
+          child: Material(
+            color: Colors.transparent,
+            child: InkWell(
+              onTap: () {
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                  behavior: SnackBarBehavior.floating,
+                  content: Text('$name is not a member.'),
+                ));
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+//TODO: Add a group tile
+//TODO: Add a group screen

--- a/lib/ui/widgets/group_tile.dart
+++ b/lib/ui/widgets/group_tile.dart
@@ -45,9 +45,7 @@ class GroupTile extends StatelessWidget {
             ],
           );
         },
-        openBuilder: (_, __) => GroupScreen(pk: group.pk)
-        //openBuilder: (_, __) => ProfileScreen(pk: member.pk, member: member),
-        );
+        openBuilder: (_, __) => GroupScreen(pk: group.pk));
   }
 }
 
@@ -113,5 +111,3 @@ class DefaultMemberTile extends StatelessWidget {
     );
   }
 }
-//TODO: Add a group tile
-//TODO: Add a group screen

--- a/lib/ui/widgets/group_tile.dart
+++ b/lib/ui/widgets/group_tile.dart
@@ -15,42 +15,41 @@ class GroupTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return OpenContainer(
-      tappable: false,
-      routeSettings: RouteSettings(name: 'Group(${group.pk})'),
-      transitionType: ContainerTransitionType.fadeThrough,
-      closedShape: const RoundedRectangleBorder(),
-      closedBuilder: (context, openContainer) {
-        return Stack(
-          fit: StackFit.expand,
-          children: [
-            CachedImage(
-              imageUrl: group.photo.small,
-              placeholder: 'assets/img/default-avatar.jpg',
-            ),
-            const _BlackGradient(),
-            Align(
-              alignment: Alignment.bottomLeft,
-              child: Padding(
-                padding: const EdgeInsets.all(8.0),
-                child: Text(
-                  group.name,
-                  style: Theme.of(context).primaryTextTheme.bodyText2,
+        tappable: false,
+        routeSettings: RouteSettings(name: 'Group(${group.pk})'),
+        transitionType: ContainerTransitionType.fadeThrough,
+        closedShape: const RoundedRectangleBorder(),
+        closedBuilder: (context, openContainer) {
+          return Stack(
+            fit: StackFit.expand,
+            children: [
+              CachedImage(
+                imageUrl: group.photo.small,
+                placeholder: 'assets/img/default-avatar.jpg',
+              ),
+              const _BlackGradient(),
+              Align(
+                alignment: Alignment.bottomLeft,
+                child: Padding(
+                  padding: const EdgeInsets.all(8.0),
+                  child: Text(
+                    group.name,
+                    style: Theme.of(context).primaryTextTheme.bodyText2,
+                  ),
                 ),
               ),
-            ),
-            Positioned.fill(
-              child: Material(
-                color: Colors.transparent,
-                child: InkWell(onTap: openContainer),
+              Positioned.fill(
+                child: Material(
+                  color: Colors.transparent,
+                  child: InkWell(onTap: openContainer),
+                ),
               ),
-            ),
-          ],
+            ],
+          );
+        },
+        openBuilder: (_, __) => GroupScreen(pk: group.pk)
+        //openBuilder: (_, __) => ProfileScreen(pk: member.pk, member: member),
         );
-      },
-      //TODO: GroupScreen
-      openBuilder: (_, __) => GroupScreen(pk: group.pk, group: group)
-      //openBuilder: (_, __) => ProfileScreen(pk: member.pk, member: member),
-    );
   }
 }
 

--- a/lib/ui/widgets/group_tile.dart
+++ b/lib/ui/widgets/group_tile.dart
@@ -1,8 +1,6 @@
 import 'package:animations/animations.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:reaxit/models/group.dart';
-import 'package:reaxit/ui/screens/groups_screen.dart';
 
 import '../screens/group_screen.dart';
 import 'cached_image.dart';

--- a/lib/ui/widgets/group_tile.dart
+++ b/lib/ui/widgets/group_tile.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:reaxit/models/group.dart';
 import 'package:reaxit/ui/screens/groups_screen.dart';
 
+import '../screens/group_screen.dart';
 import 'cached_image.dart';
 
 class GroupTile extends StatelessWidget {
@@ -47,7 +48,7 @@ class GroupTile extends StatelessWidget {
         );
       },
       //TODO: GroupScreen
-      openBuilder: (_, __) => GroupsScreen(),
+      openBuilder: (_, __) => GroupScreen(pk: group.pk, group: group)
       //openBuilder: (_, __) => ProfileScreen(pk: member.pk, member: member),
     );
   }

--- a/lib/ui/widgets/group_tile.dart
+++ b/lib/ui/widgets/group_tile.dart
@@ -13,39 +13,40 @@ class GroupTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return OpenContainer(
-        tappable: false,
-        routeSettings: RouteSettings(name: 'Group(${group.pk})'),
-        transitionType: ContainerTransitionType.fadeThrough,
-        closedShape: const RoundedRectangleBorder(),
-        closedBuilder: (context, openContainer) {
-          return Stack(
-            fit: StackFit.expand,
-            children: [
-              CachedImage(
-                imageUrl: group.photo.small,
-                placeholder: 'assets/img/default-avatar.jpg',
-              ),
-              const _BlackGradient(),
-              Align(
-                alignment: Alignment.bottomLeft,
-                child: Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: Text(
-                    group.name,
-                    style: Theme.of(context).primaryTextTheme.bodyText2,
-                  ),
+      tappable: false,
+      routeSettings: RouteSettings(name: 'Group(${group.pk})'),
+      transitionType: ContainerTransitionType.fadeThrough,
+      closedShape: const RoundedRectangleBorder(),
+      closedBuilder: (context, openContainer) {
+        return Stack(
+          fit: StackFit.expand,
+          children: [
+            CachedImage(
+              imageUrl: group.photo.small,
+              placeholder: 'assets/img/default-avatar.jpg',
+            ),
+            const _BlackGradient(),
+            Align(
+              alignment: Alignment.bottomLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  group.name,
+                  style: Theme.of(context).primaryTextTheme.bodyText2,
                 ),
               ),
-              Positioned.fill(
-                child: Material(
-                  color: Colors.transparent,
-                  child: InkWell(onTap: openContainer),
-                ),
+            ),
+            Positioned.fill(
+              child: Material(
+                color: Colors.transparent,
+                child: InkWell(onTap: openContainer),
               ),
-            ],
-          );
-        },
-        openBuilder: (_, __) => GroupScreen(pk: group.pk));
+            ),
+          ],
+        );
+      },
+      openBuilder: (_, __) => GroupScreen(pk: group.pk),
+    );
   }
 }
 

--- a/lib/ui/widgets/menu_drawer.dart
+++ b/lib/ui/widgets/menu_drawer.dart
@@ -199,6 +199,18 @@ class MenuDrawer extends StatelessWidget {
             },
           ),
           ListTile(
+            title: const Text('Groups'),
+            leading: const Icon(Icons.people),
+            selected: router.location == '/groups',
+            onTap: () {
+              if (router.location.startsWith('/groups')) {
+                Navigator.of(context).pop();
+              } else {
+                context.goNamed('groups');
+              }
+            },
+          ),
+          ListTile(
             title: const Text('Settings'),
             leading: const Icon(Icons.settings),
             selected: router.location == '/settings',

--- a/lib/ui/widgets/menu_drawer.dart
+++ b/lib/ui/widgets/menu_drawer.dart
@@ -200,7 +200,7 @@ class MenuDrawer extends StatelessWidget {
           ),
           ListTile(
             title: const Text('Groups'),
-            leading: const Icon(Icons.people),
+            leading: const Icon(Icons.groups),
             selected: router.location == '/groups',
             onTap: () {
               if (router.location.startsWith('/groups')) {


### PR DESCRIPTION
Closes #54 

### Summary
Adds a page containing the groups (including Societies, Committees, and Boards) to the app

### How to test
Steps to test the changes you made:
1. Open the side-bar by pressing the hamburger button
2. Click on 'Groups'
