### PR TITLE
Use fixed photo_view for flutter 2.10.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.1.11"
   args:
     dependency: transitive
     description:
@@ -320,7 +320,7 @@ packages:
       name: flutter_blurhash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.0"
   flutter_cache_manager:
     dependency: "direct main"
     description:
@@ -414,7 +414,7 @@ packages:
       name: flutter_widget_from_html_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5+1"
+    version: "0.8.4"
   frontend_server_client:
     dependency: transitive
     description:
@@ -449,7 +449,7 @@ packages:
       name: google_fonts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.0"
   graphs:
     dependency: transitive
     description:
@@ -477,7 +477,7 @@ packages:
       name: http_multi_server
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.0.1"
   http_parser:
     dependency: "direct main"
     description:
@@ -505,21 +505,21 @@ packages:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+9"
+    version: "0.8.4+6"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.5"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.4"
+    version: "2.4.3"
   intl:
     dependency: "direct main"
     description:
@@ -638,7 +638,7 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.0"
   package_info_plus_linux:
     dependency: transitive
     description:
@@ -687,7 +687,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.8"
   path_provider_android:
     dependency: transitive
     description:
@@ -754,9 +754,11 @@ packages:
   photo_view:
     dependency: "direct main"
     description:
-      name: photo_view
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "."
+      ref: "8156907eecfa812b181a5a729d790f6d399f311b"
+      resolved-ref: "8156907eecfa812b181a5a729d790f6d399f311b"
+      url: "https://github.com/bluefireteam/photo_view"
+    source: git
     version: "0.13.0"
   platform:
     dependency: transitive
@@ -834,7 +836,7 @@ packages:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.4"
   share_plus_linux:
     dependency: transitive
     description:
@@ -883,28 +885,28 @@ packages:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.10"
   shared_preferences_ios:
     dependency: transitive
     description:
       name: shared_preferences_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.10"
+    version: "2.0.9"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.0.4"
   shared_preferences_macos:
     dependency: transitive
     description:
       name: shared_preferences_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.2"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
@@ -925,7 +927,7 @@ packages:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.0.4"
   shelf:
     dependency: transitive
     description:
@@ -979,7 +981,7 @@ packages:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.0.1+1"
   stack_trace:
     dependency: transitive
     description:
@@ -1063,35 +1065,35 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.20"
+    version: "6.0.18"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.15"
+    version: "6.0.14"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.15"
+    version: "6.0.14"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.3"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.3"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1105,14 +1107,14 @@ packages:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.7"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "2.0.2"
   uuid:
     dependency: transitive
     description:
@@ -1147,7 +1149,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.3.6"
   xdg_directories:
     dependency: transitive
     description:
@@ -1171,4 +1173,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=2.16.0 <3.0.0"
-  flutter: ">=2.10.0"
+  flutter: ">=2.6.0-0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,13 @@ dependencies:
   flutter_web_auth: ^0.4.0
 
   # Modal photo views.
-  photo_view: ^0.13.0
+  photo_view: 
+    # photo_view 0.13.0 is not compatible with flutter 2.10.x The fix has not 
+    # been released yet, so we temporarily reference the fix by a git reference.
+    # See: https://github.com/svthalia/Reaxit/issues/206
+    git:
+      url: https://github.com/bluefireteam/photo_view
+      ref: 8156907eecfa812b181a5a729d790f6d399f311b
 
   # HTML widget.
   flutter_widget_from_html_core: ^0.8.4


### PR DESCRIPTION
photo_view 0.13.0 is not compatible with flutter 2.10.x. The fix (https://github.com/bluefireteam/photo_view/pull/499) has not been released yet. For the time being, we use a reference directly to that commit, rather than the released version. When the fix is released, we should change this back to the new version '0.13.1' or '0.14.0'. I've opened #207 to track that.