### PR TITLE
Fix exception on empty pushnotification

### DIFF
--- a/lib/ui/widgets/push_notification_dialog.dart
+++ b/lib/ui/widgets/push_notification_dialog.dart
@@ -16,8 +16,8 @@ class PushNotificationDialog extends StatelessWidget {
     }
 
     return AlertDialog(
-      title: Text(message.notification!.title!),
-      content: (message.notification!.body != null &&
+      title: Text(message.notification?.title ?? 'Notification'),
+      content: (message.notification?.body != null &&
               message.notification!.body!.isNotEmpty)
           ? Text(
               message.notification!.body!,


### PR DESCRIPTION
This prevents exceptions form being thrown when a PushNotificationDialog is shown while the push notification has no title or body.