### PR TITLE
Fix map image cache keys

### DIFF
--- a/lib/ui/widgets/cached_image.dart
+++ b/lib/ui/widgets/cached_image.dart
@@ -27,16 +27,21 @@ class CachedImage extends CachedNetworkImage {
     Duration fadeInDuration = const Duration(milliseconds: 200),
     required String placeholder,
   }) : super(
+          key: ValueKey(imageUrl),
           imageUrl: imageUrl,
           cacheManager: _ThaliaCacheManager(),
 
-          /// Remove the query part of the url from its key in the cache.
-          /// Private images from concrexit have a signature in the url that
-          /// expires every 3 hours. Removing this signature makes sure that
-          /// the same cache object can be used regardless of the signature.
-          /// This assumes that the qurey part is only used for authentication,
-          /// not to identify the image, so the remaining path is a unique key.
-          cacheKey: Uri.parse(imageUrl).replace(query: '').toString(),
+          /// If the image is from thalia.nu, remove the query part of the url
+          /// from its key in the cache. Private images from concrexit have a
+          /// signature in the url that expires every 3 hours. Removing this
+          /// signature makes sure that the same cache object can be used
+          /// regardless of the signature. This assumes that the qurey part is
+          /// only used for authentication, not to identify the image, so the
+          /// remaining path is a unique key.
+          /// If the url is not from thalia.nu, use the full url as the key.
+          cacheKey: Uri.parse(imageUrl).host == config.apiHost
+              ? Uri.parse(imageUrl).replace(query: '').toString()
+              : imageUrl,
           fit: fit,
           fadeOutDuration: fadeOutDuration,
           fadeInDuration: fadeInDuration,


### PR DESCRIPTION
Fixes an issue where map images where cached with the same key (that doesnt contain query parameters), leading to all events showing the same map.