### PR TITLE
Catch HandshakeExceptions

### DIFF
--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -103,6 +103,8 @@ class ConcrexitApiRepository implements ApiRepository {
       throw ApiException.unknownError;
     } on http.ClientException catch (_) {
       throw ApiException.unknownError;
+    } on HandshakeException catch (_) {
+      throw ApiException.unknownError;
     } on OSError catch (_) {
       throw ApiException.unknownError;
     } on ApiException catch (_) {


### PR DESCRIPTION
Catches some not-so-exceptional exceptions (network stuff) that clutters sentry.