### PR TITLE
Event search shows newer events first

### DIFF
--- a/lib/blocs/calendar_cubit.dart
+++ b/lib/blocs/calendar_cubit.dart
@@ -177,7 +177,18 @@ class CalendarCubit extends Cubit<CalendarState> {
 
       // Merge the two lists.
       events.addAll(partnerEvents);
-      events.sort((a, b) => a.start.compareTo(b.start));
+      events.sort((a, b) {
+        if (searchQuery == null) {
+          return a.start.compareTo(b.start);
+        } else {
+          // Sorts on isBeforeNow > date
+          int result =
+              a.end.isBefore(DateTime.now()) && b.end.isBefore(DateTime.now())
+                  ? 0
+                  : (a.end.isBefore(DateTime.now()) ? 1 : -1);
+          return result == 0 ? a.start.compareTo(b.start) : result;
+        }
+      });
 
       // If `load()` and `more()` cause jank, the expensive operations
       // on the events could be moved to an isolate in `compute()`.


### PR DESCRIPTION
Closes #175  

### Summary
This PR changes the way events are sorted under the search menu. It will now first show events that have not ended and then sorted on date.

### How to test
1. Go to 'Events'
2. Click on 'The search icon'
3. Fill in a query
4. Observe
