### PR TITLE
Update photo_view to 0.14.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -768,12 +768,10 @@ packages:
   photo_view:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "8156907eecfa812b181a5a729d790f6d399f311b"
-      resolved-ref: "8156907eecfa812b181a5a729d790f6d399f311b"
-      url: "https://github.com/bluefireteam/photo_view"
-    source: git
-    version: "0.13.0"
+      name: photo_view
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.0"
   platform:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,13 +59,7 @@ dependencies:
   flutter_web_auth: ^0.4.0
 
   # Modal photo views.
-  photo_view: 
-    # photo_view 0.13.0 is not compatible with flutter 2.10.x The fix has not 
-    # been released yet, so we temporarily reference the fix by a git reference.
-    # See: https://github.com/svthalia/Reaxit/issues/206
-    git:
-      url: https://github.com/bluefireteam/photo_view
-      ref: 8156907eecfa812b181a5a729d790f6d399f311b
+  photo_view: ^0.14.0
 
   # HTML widget.
   flutter_widget_from_html_core: ^0.8.4


### PR DESCRIPTION
This gets rid of the git reference we used while waiting for this update.
See #207.

This may also resolve some out-of-memory crashes related to storing image scale state in long galleries (https://github.com/bluefireteam/photo_view/pull/479).

Closes #206.

