### PR TITLE
Fix admin screen name overflows

### DIFF
--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -126,6 +126,7 @@ class __RegistrationTileState extends State<_RegistrationTile> {
     final name = registration.member?.fullName ?? registration.name!;
 
     final presentCheckbox = Checkbox(
+      visualDensity: VisualDensity.compact,
       value: present,
       onChanged: (value) async {
         final oldValue = present;
@@ -222,7 +223,12 @@ class __RegistrationTileState extends State<_RegistrationTile> {
     }
 
     return ListTile(
-      title: Text(name, maxLines: 1),
+      horizontalTitleGap: 8,
+      title: Text(
+        name,
+        maxLines: 2,
+        overflow: TextOverflow.ellipsis,
+      ),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/ui/screens/food_admin_screen.dart
+++ b/lib/ui/screens/food_admin_screen.dart
@@ -174,8 +174,17 @@ class __OderTileState extends State<_OrderTile> {
     }
 
     return ListTile(
-      title: Text(name, maxLines: 1),
-      subtitle: Text(order.product.name),
+      horizontalTitleGap: 8,
+      title: Text(
+        name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        order.product.name,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [

--- a/lib/ui/screens/food_screen.dart
+++ b/lib/ui/screens/food_screen.dart
@@ -276,12 +276,17 @@ class _FoodScreenState extends State<FoodScreen> {
                     crossAxisAlignment: CrossAxisAlignment.stretch,
                     children: [
                       Row(
+                        textBaseline: TextBaseline.alphabetic,
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        crossAxisAlignment: CrossAxisAlignment.end,
+                        crossAxisAlignment: CrossAxisAlignment.baseline,
                         children: [
-                          Text(
-                            order.product.name,
-                            style: Theme.of(context).textTheme.headline6,
+                          Expanded(
+                            child: Text(
+                              order.product.name,
+                              style: Theme.of(context).textTheme.headline6,
+                              overflow: TextOverflow.ellipsis,
+                              maxLines: 1,
+                            ),
                           ),
                           Text(
                             order.isPaid


### PR DESCRIPTION
Closes #220.

This handles overflows in food/event admin screens and FoodScreen.

