### PR TITLE
Upgrade to flutter 3.0.2

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.0.1
+          flutter-version: 3.0.2
           channel: stable
           cache: true
           
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.0.1
+          flutter-version: 3.0.2
           channel: stable
           cache: true
           

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 2.10.3
+          flutter-version: 3.0.1
           channel: stable
           cache: true
           
@@ -97,7 +97,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 2.10.3
+          flutter-version: 3.0.1
           channel: stable
           cache: true
           

--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 2.10.3
+          flutter-version: 3.0.1
           channel: stable
           cache: true
           
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 2.10.3
+          flutter-version: 3.0.1
           channel: stable
           cache: true
           

--- a/.github/workflows/codestyle.yaml
+++ b/.github/workflows/codestyle.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.0.1
+          flutter-version: 3.0.2
           channel: stable
           cache: true
           
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.0.1
+          flutter-version: 3.0.2
           channel: stable
           cache: true
           

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.0.1
+          flutter-version: 3.0.2
           channel: stable
           cache: true
           
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 3.0.1
+          flutter-version: 3.0.2
           channel: stable
           cache: true
           

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 2.10.3
+          flutter-version: 3.0.1
           channel: stable
           cache: true
           
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
         with:
-          flutter-version: 2.10.3
+          flutter-version: 3.0.1
           channel: stable
           cache: true
           

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,3 +17,6 @@ linter:
 
     avoid_catching_errors: true
     avoid_escaping_inner_quotes: true
+
+    # TODO: Refactor so that we can enable this rule. See #228.
+    use_build_context_synchronously: false

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,33 +1,33 @@
 PODS:
   - add_2_calendar (0.0.1):
     - Flutter
-  - Firebase/CoreOnly (8.14.0):
-    - FirebaseCore (= 8.14.0)
-  - Firebase/Messaging (8.14.0):
+  - Firebase/CoreOnly (8.15.0):
+    - FirebaseCore (= 8.15.0)
+  - Firebase/Messaging (8.15.0):
     - Firebase/CoreOnly
-    - FirebaseMessaging (~> 8.14.0)
-  - firebase_core (1.14.0):
-    - Firebase/CoreOnly (= 8.14.0)
+    - FirebaseMessaging (~> 8.15.0)
+  - firebase_core (1.17.1):
+    - Firebase/CoreOnly (= 8.15.0)
     - Flutter
-  - firebase_messaging (11.2.12):
-    - Firebase/Messaging (= 8.14.0)
+  - firebase_messaging (11.4.1):
+    - Firebase/Messaging (= 8.15.0)
     - firebase_core
     - Flutter
-  - FirebaseCore (8.14.0):
+  - FirebaseCore (8.15.0):
     - FirebaseCoreDiagnostics (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
-  - FirebaseCoreDiagnostics (8.14.0):
+  - FirebaseCoreDiagnostics (8.15.0):
     - GoogleDataTransport (~> 9.1)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/Logger (~> 7.7)
     - nanopb (~> 2.30908.0)
-  - FirebaseInstallations (8.14.0):
+  - FirebaseInstallations (8.15.0):
     - FirebaseCore (~> 8.0)
     - GoogleUtilities/Environment (~> 7.7)
     - GoogleUtilities/UserDefaults (~> 7.7)
     - PromisesObjC (< 3.0, >= 1.2)
-  - FirebaseMessaging (8.14.0):
+  - FirebaseMessaging (8.15.0):
     - FirebaseCore (~> 8.0)
     - FirebaseInstallations (~> 8.0)
     - GoogleDataTransport (~> 9.1)
@@ -46,9 +46,9 @@ PODS:
   - FMDB/standard (2.7.5)
   - gallery_saver (0.0.1):
     - Flutter
-  - GoogleDataTransport (9.1.2):
-    - GoogleUtilities/Environment (~> 7.2)
-    - nanopb (~> 2.30908.0)
+  - GoogleDataTransport (9.1.4):
+    - GoogleUtilities/Environment (~> 7.7)
+    - nanopb (< 2.30910.0, >= 2.30908.0)
     - PromisesObjC (< 3.0, >= 1.2)
   - GoogleUtilities/AppDelegateSwizzler (7.7.0):
     - GoogleUtilities/Environment
@@ -81,14 +81,14 @@ PODS:
     - Flutter
   - path_provider_ios (0.0.1):
     - Flutter
-  - PromisesObjC (2.0.0)
-  - Sentry (7.10.2):
-    - Sentry/Core (= 7.10.2)
-  - Sentry/Core (7.10.2)
+  - PromisesObjC (2.1.0)
+  - Sentry (7.11.0):
+    - Sentry/Core (= 7.11.0)
+  - Sentry/Core (7.11.0)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry (~> 7.10.1)
+    - Sentry (~> 7.11.0)
   - share_plus (0.0.1):
     - Flutter
   - shared_preferences_ios (0.0.1):
@@ -169,28 +169,28 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   add_2_calendar: e9d68636aed37fb18e12f5a3d74c2e0589487af0
-  Firebase: 7e8fe528c161b9271d365217a74c16aaf834578e
-  firebase_core: b0b382f1497ab407aceb25e41e3036c8798c1609
-  firebase_messaging: 34dd10d1aa6d8f40d03660eeacd0452d62eec7aa
-  FirebaseCore: b84a44ee7ba999e0f9f76d198a9c7f60a797b848
-  FirebaseCoreDiagnostics: fd0c8490f34287229c1d6c103d3a55f81ec85712
-  FirebaseInstallations: 7d1d967a307c12f1aadd76844fc321cef699b1ce
-  FirebaseMessaging: 5ebc42d281567658a2cb72b9ef3506e4a1a1a6e4
+  Firebase: 5f8193dff4b5b7c5d5ef72ae54bb76c08e2b841d
+  firebase_core: 318de541b0e61d3f24262982a3f0b54afe72439b
+  firebase_messaging: 943cfe65e0b3f457240489ce67655e40da1d270c
+  FirebaseCore: 5743c5785c074a794d35f2fff7ecc254a91e08b1
+  FirebaseCoreDiagnostics: 92e07a649aeb66352b319d43bdd2ee3942af84cb
+  FirebaseInstallations: 40bd9054049b2eae9a2c38ef1c3dd213df3605cd
+  FirebaseMessaging: 5e5118a2383b3531e730d974680954c679ca0a13
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   flutter_secure_storage: 7953c38a04c3fdbb00571bcd87d8e3b5ceb9daec
   flutter_web_auth: 09a0abd245f1a07a3ff4dcf1247a048d89ee12a9
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   gallery_saver: 9fc173c9f4fcc48af53b2a9ebea1b643255be542
-  GoogleDataTransport: 629c20a4d363167143f30ea78320d5a7eb8bd940
+  GoogleDataTransport: 5fffe35792f8b96ec8d6775f5eccd83c998d5a3b
   GoogleUtilities: e0913149f6b0625b553d70dae12b49fc62914fd1
   image_cropper: 60c2789d1f1a78c873235d4319ca0c34a69f2d98
   image_picker_ios: b786a5dcf033a8336a657191401bfdf12017dabb
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   path_provider_ios: 14f3d2fd28c4fdb42f44e0f751d12861c43cee02
-  PromisesObjC: 68159ce6952d93e17b2dfe273b8c40907db5ba58
-  Sentry: 7bf9bfe713692cf87812e55f0999260494ba7982
-  sentry_flutter: 77ccdac346608b8ce7e428e7284e7a3e4e7f4a02
+  PromisesObjC: 99b6f43f9e1044bd87a95a60beff28c2c44ddb72
+  Sentry: 0c5cd63d714187b4a39c331c1f0eb04ba7868341
+  sentry_flutter: efb3df2c203cd03aad255892a8d628a458656d14
   share_plus: 056a1e8ac890df3e33cb503afffaf1e9b4fbae68
   shared_preferences_ios: 548a61f8053b9b8a49ac19c1ffbc8b92c50d68ad
   sqflite: 6d358c025f5b867b29ed92fc697fd34924e11904

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -76,5 +76,7 @@
 		<false/>
 		<key>UIStatusBarHidden</key>
 		<false/>
-	</dict>
+		<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+</dict>
 </plist>

--- a/lib/api/api_repository.dart
+++ b/lib/api/api_repository.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:reaxit/models/album.dart';
 import 'package:reaxit/models/push_notification_category.dart';
 import 'package:reaxit/models/event.dart';
@@ -265,8 +263,8 @@ abstract class ApiRepository {
 
   /// Update the avatar of the logged in member.
   ///
-  /// `file` should be a jpg image.
-  Future<void> updateAvatar(File file);
+  /// `filePath` should be the path of a jpg image.
+  Future<void> updateAvatar(String file);
 
   /// Update the description of the logged in member.
   Future<void> updateDescription(String description);

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -884,14 +884,14 @@ class ConcrexitApiRepository implements ApiRepository {
   }
 
   @override
-  Future<void> updateAvatar(File file) async {
+  Future<void> updateAvatar(String filePath) async {
     try {
       final uri = _baseUri.replace(path: '$_basePath/members/me/');
       final request = http.MultipartRequest('PATCH', uri);
       request.files.add(
         await http.MultipartFile.fromPath(
           'profile.photo',
-          file.path,
+          filePath,
           contentType: MediaType('image', 'jpeg'),
         ),
       );

--- a/lib/blocs/album_list_cubit.dart
+++ b/lib/blocs/album_list_cubit.dart
@@ -66,12 +66,12 @@ class AlbumListCubit extends Cubit<AlbumListState> {
   }
 
   Future<void> more() async {
-    final _state = state;
+    final oldState = state;
 
     // Ignore calls to `more()` if there is no data, or already more coming.
-    if (_state.isDone || _state.isLoading || _state.isLoadingMore) return;
+    if (oldState.isDone || oldState.isLoading || oldState.isLoadingMore) return;
 
-    emit(_state.copyWith(isLoadingMore: true));
+    emit(oldState.copyWith(isLoadingMore: true));
     try {
       final query = _searchQuery;
 

--- a/lib/blocs/calendar_cubit.dart
+++ b/lib/blocs/calendar_cubit.dart
@@ -71,7 +71,7 @@ class CalendarEvent {
       return [
         CalendarEvent._(
           parentEvent: event,
-          title: event.title + ' day 1/$daySpan',
+          title: '${event.title} day 1/$daySpan',
           start: event.start,
           end: _addDays(startDate, 1),
           label: 'From $startTime | ${event.location}',
@@ -79,14 +79,14 @@ class CalendarEvent {
         for (var day in Iterable.generate(daySpan - 2, (i) => i + 2))
           CalendarEvent._(
             parentEvent: event,
-            title: event.title + ' day $day/$daySpan',
+            title: '${event.title} day $day/$daySpan',
             start: _addDays(startDate, day - 1),
             end: _addDays(startDate, day),
             label: event.location,
           ),
         CalendarEvent._(
           parentEvent: event,
-          title: event.title + ' day $daySpan/$daySpan',
+          title: '${event.title} day $daySpan/$daySpan',
           start: endDate,
           end: event.end,
           label: 'Until $endTime | ${event.location}',
@@ -219,12 +219,12 @@ class CalendarCubit extends Cubit<CalendarState> {
   }
 
   Future<void> more() async {
-    final _state = state;
+    final oldState = state;
 
     // Ignore calls to `more()` if there is no data, or already more coming.
-    if (_state.isDone || _state.isLoading || _state.isLoadingMore) return;
+    if (oldState.isDone || oldState.isLoading || oldState.isLoadingMore) return;
 
-    emit(_state.copyWith(isLoadingMore: true));
+    emit(oldState.copyWith(isLoadingMore: true));
     try {
       final query = _searchQuery;
       final start = query == null ? _lastLoadTime : null;
@@ -259,7 +259,7 @@ class CalendarCubit extends Cubit<CalendarState> {
       newEvents.sort((a, b) => a.start.compareTo(b.start));
 
       final events = [
-        ..._state.results,
+        ...oldState.results,
         ...newEvents,
       ];
 

--- a/lib/blocs/full_member_cubit.dart
+++ b/lib/blocs/full_member_cubit.dart
@@ -1,6 +1,5 @@
-import 'dart:io';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:image_cropper/image_cropper.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/blocs/detail_state.dart';
 import 'package:reaxit/models/member.dart';
@@ -27,8 +26,8 @@ class FullMemberCubit extends Cubit<FullMemberState> {
     }
   }
 
-  Future<void> updateAvatar(File file) async {
-    await api.updateAvatar(file);
+  Future<void> updateAvatar(CroppedFile file) async {
+    await api.updateAvatar(file.path);
     await load();
   }
 

--- a/lib/blocs/member_list_cubit.dart
+++ b/lib/blocs/member_list_cubit.dart
@@ -66,12 +66,12 @@ class MemberListCubit extends Cubit<MemberListState> {
   }
 
   Future<void> more() async {
-    final _state = state;
+    final oldState = state;
 
     // Ignore calls to `more()` if there is no data, or already more coming.
-    if (_state.isDone || _state.isLoading || _state.isLoadingMore) return;
+    if (oldState.isDone || oldState.isLoading || oldState.isLoadingMore) return;
 
-    emit(_state.copyWith(isLoadingMore: true));
+    emit(oldState.copyWith(isLoadingMore: true));
     try {
       final query = _searchQuery;
 

--- a/lib/blocs/registrations_cubit.dart
+++ b/lib/blocs/registrations_cubit.dart
@@ -42,11 +42,11 @@ class RegistrationsCubit extends Cubit<RegistrationsState> {
   }
 
   Future<void> more() async {
-    final _state = state;
+    final oldState = state;
 
-    if (_state.isDone || _state.isLoading || _state.isLoadingMore) return;
+    if (oldState.isDone || oldState.isLoading || oldState.isLoadingMore) return;
 
-    emit(_state.copyWith(isLoadingMore: true));
+    emit(oldState.copyWith(isLoadingMore: true));
 
     try {
       var listResponse = await api.getEventRegistrations(

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -60,8 +60,9 @@ final Uri changelogUri = Uri.parse(
   'https://github.com/svthalia/Reaxit/releases',
 );
 
-const String termsAndConditionsUrl =
-    'https://staging.thalia.nu/event-registration-terms/';
+final Uri termsAndConditionsUrl = Uri.parse(
+  'https://staging.thalia.nu/event-registration-terms/',
+);
 
 /// The period after which objects are removed from the cache when not used.
 const Duration cacheStalePeriod = Duration(days: 30);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -46,7 +46,7 @@ Future<void> main() async {
 
 class ThaliApp extends StatefulWidget {
   @override
-  _ThaliAppState createState() => _ThaliAppState();
+  State<ThaliApp> createState() => _ThaliAppState();
 }
 
 class _ThaliAppState extends State<ThaliApp> {
@@ -76,11 +76,7 @@ class _ThaliAppState extends State<ThaliApp> {
               query: uri.query,
             ).toString());
           } else {
-            await launch(
-              uri.toString(),
-              forceSafariVC: false,
-              forceWebView: false,
-            );
+            await launchUrl(uri, mode: LaunchMode.externalApplication);
           }
         }
       } else if (navigatorKey.currentContext != null) {
@@ -107,11 +103,7 @@ class _ThaliAppState extends State<ThaliApp> {
               query: uri.query,
             ).toString());
           } else {
-            await launch(
-              uri.toString(),
-              forceSafariVC: false,
-              forceWebView: false,
-            );
+            await launchUrl(uri, mode: LaunchMode.externalApplication);
           }
         }
       } else if (navigatorKey.currentContext != null) {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -272,6 +272,7 @@ class _ThaliAppState extends State<ThaliApp> {
             themeMode: themeMode,
             routerDelegate: _router.routerDelegate,
             routeInformationParser: _router.routeInformationParser,
+            routeInformationProvider: _router.routeInformationProvider,
           ),
         );
       },

--- a/lib/models/member.dart
+++ b/lib/models/member.dart
@@ -4,7 +4,9 @@ import 'package:reaxit/models/photo.dart';
 part 'member.g.dart';
 
 enum Programme { computingscience, informationscience }
+
 enum MembershipType { member, benefactor, honorary }
+
 enum DisplayNamePreference {
   full,
   nickname,

--- a/lib/ui/screens/album_screen.dart
+++ b/lib/ui/screens/album_screen.dart
@@ -23,7 +23,7 @@ class AlbumScreen extends StatefulWidget {
   AlbumScreen({required this.slug, this.album}) : super(key: ValueKey(slug));
 
   @override
-  _AlbumScreenState createState() => _AlbumScreenState();
+  State<AlbumScreen> createState() => _AlbumScreenState();
 }
 
 class _AlbumScreenState extends State<AlbumScreen> {

--- a/lib/ui/screens/albums_screen.dart
+++ b/lib/ui/screens/albums_screen.dart
@@ -10,7 +10,7 @@ import 'package:reaxit/ui/widgets/menu_drawer.dart';
 
 class AlbumsScreen extends StatefulWidget {
   @override
-  _AlbumsScreenState createState() => _AlbumsScreenState();
+  State<AlbumsScreen> createState() => _AlbumsScreenState();
 }
 
 class _AlbumsScreenState extends State<AlbumsScreen> {

--- a/lib/ui/screens/calendar_screen.dart
+++ b/lib/ui/screens/calendar_screen.dart
@@ -15,7 +15,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 class CalendarScreen extends StatefulWidget {
   @override
-  _CalendarScreenState createState() => _CalendarScreenState();
+  State<CalendarScreen> createState() => _CalendarScreenState();
 }
 
 class _CalendarScreenState extends State<CalendarScreen> {
@@ -252,10 +252,6 @@ class CalendarScrollView extends StatelessWidget {
                   final dayGroupedEvents = _groupByDay(events);
                   final days = dayGroupedEvents.keys.toList();
 
-                  // TODO: StickyHeaders currently cause silent exceptions
-                  //  when they build. This is only visible while catching
-                  //  'All Exceptions', and does not affect the user. See
-                  //  https://github.com/fluttercommunity/flutter_sticky_headers/issues/39.
                   return StickyHeader(
                     header: SizedBox(
                       width: double.infinity,
@@ -385,10 +381,9 @@ class _EventCard extends StatelessWidget {
         child: InkWell(
           onTap: () {
             if (event.parentEvent is PartnerEvent) {
-              launch(
-                (event.parentEvent as PartnerEvent).url.toString(),
-                forceSafariVC: false,
-                forceWebView: false,
+              launchUrl(
+                (event.parentEvent as PartnerEvent).url,
+                mode: LaunchMode.externalApplication,
               );
             } else {
               context.pushNamed(

--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -14,7 +14,7 @@ class EventAdminScreen extends StatefulWidget {
   EventAdminScreen({required this.pk}) : super(key: ValueKey(pk));
 
   @override
-  _EventAdminScreenState createState() => _EventAdminScreenState();
+  State<EventAdminScreen> createState() => _EventAdminScreenState();
 }
 
 class _EventAdminScreenState extends State<EventAdminScreen> {

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -29,7 +29,7 @@ class EventScreen extends StatefulWidget {
   EventScreen({required this.pk, this.event}) : super(key: ValueKey(pk));
 
   @override
-  _EventScreenState createState() => _EventScreenState();
+  State<EventScreen> createState() => _EventScreenState();
 }
 
 class _EventScreenState extends State<EventScreen> {
@@ -83,18 +83,15 @@ class _EventScreenState extends State<EventScreen> {
                 Uri url = Theme.of(context).platform == TargetPlatform.iOS
                     ? Uri(
                         scheme: 'maps',
-                        queryParameters: {'daddr': event.location})
+                        queryParameters: {'daddr': event.location},
+                      )
                     : Uri(
                         scheme: 'https',
                         host: 'maps.google.com',
                         path: 'maps',
                         queryParameters: {'daddr': event.location},
                       );
-                launch(
-                  url.toString(),
-                  forceSafariVC: false,
-                  forceWebView: false,
-                );
+                launchUrl(url, mode: LaunchMode.externalNonBrowserApplication);
               },
             ),
           ),
@@ -510,9 +507,10 @@ class _EventScreenState extends State<EventScreen> {
     return ElevatedButton.icon(
       onPressed: () async {
         try {
+          final calendarCubit = BlocProvider.of<CalendarCubit>(context);
           await _eventCubit.register();
           await _registrationsCubit.load();
-          BlocProvider.of<CalendarCubit>(context).load();
+          calendarCubit.load();
         } on ApiException {
           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
             behavior: SnackBarBehavior.floating,
@@ -529,11 +527,12 @@ class _EventScreenState extends State<EventScreen> {
     return ElevatedButton.icon(
       onPressed: () async {
         try {
+          final calendarCubit = BlocProvider.of<CalendarCubit>(context);
           await _eventCubit.cancelRegistration(
             registrationPk: event.registration!.pk,
           );
           await _registrationsCubit.load();
-          BlocProvider.of<CalendarCubit>(context).load();
+          calendarCubit.load();
         } on ApiException {
           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
             behavior: SnackBarBehavior.floating,
@@ -806,7 +805,7 @@ class _EventScreenState extends State<EventScreen> {
   }
 
   TextSpan _makeTermsAndConditions(Event event) {
-    const url = config.termsAndConditionsUrl;
+    final url = config.termsAndConditionsUrl;
     return TextSpan(
       children: [
         const TextSpan(
@@ -817,15 +816,11 @@ class _EventScreenState extends State<EventScreen> {
           recognizer: TapGestureRecognizer()
             ..onTap = () async {
               try {
-                await launch(
-                  url,
-                  forceSafariVC: false,
-                  forceWebView: false,
-                );
+                await launchUrl(url, mode: LaunchMode.externalApplication);
               } catch (_) {
-                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                ScaffoldMessenger.of(context).showSnackBar(SnackBar(
                   behavior: SnackBarBehavior.floating,
-                  content: Text('Could not open "$url".'),
+                  content: Text('Could not open "${url.toString()}".'),
                 ));
               }
             },
@@ -857,10 +852,9 @@ class _EventScreenState extends State<EventScreen> {
             return true;
           } else {
             try {
-              await launch(
-                url,
-                forceSafariVC: false,
-                forceWebView: false,
+              await launchUrl(
+                Uri.parse(url),
+                mode: LaunchMode.externalApplication,
               );
             } catch (_) {
               ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/lib/ui/screens/food_admin_screen.dart
+++ b/lib/ui/screens/food_admin_screen.dart
@@ -14,7 +14,7 @@ class FoodAdminScreen extends StatefulWidget {
   FoodAdminScreen({required this.pk}) : super(key: ValueKey(pk));
 
   @override
-  _FoodAdminScreenState createState() => _FoodAdminScreenState();
+  State<FoodAdminScreen> createState() => _FoodAdminScreenState();
 }
 
 class _FoodAdminScreenState extends State<FoodAdminScreen> {

--- a/lib/ui/screens/food_screen.dart
+++ b/lib/ui/screens/food_screen.dart
@@ -24,7 +24,7 @@ class FoodScreen extends StatefulWidget {
   FoodScreen({this.pk, this.event}) : super(key: ValueKey(pk));
 
   @override
-  _FoodScreenState createState() => _FoodScreenState();
+  State<FoodScreen> createState() => _FoodScreenState();
 }
 
 class _FoodScreenState extends State<FoodScreen> {
@@ -476,7 +476,7 @@ class __ProductTileState extends State<_ProductTile> {
       title: Text.rich(
         TextSpan(
           children: [
-            TextSpan(text: widget.product.name + ' '),
+            TextSpan(text: '${widget.product.name} '),
             TextSpan(
               text: '€${widget.product.price}',
               style: Theme.of(context).textTheme.caption!.copyWith(

--- a/lib/ui/screens/login_screen.dart
+++ b/lib/ui/screens/login_screen.dart
@@ -6,7 +6,7 @@ class LoginScreen extends StatefulWidget {
   const LoginScreen({Key? key}) : super(key: key);
 
   @override
-  _LoginScreenState createState() => _LoginScreenState();
+  State<LoginScreen> createState() => _LoginScreenState();
 }
 
 class _LoginScreenState extends State<LoginScreen> {

--- a/lib/ui/screens/members_screen.dart
+++ b/lib/ui/screens/members_screen.dart
@@ -10,7 +10,7 @@ import 'package:reaxit/ui/widgets/menu_drawer.dart';
 
 class MembersScreen extends StatefulWidget {
   @override
-  _MembersScreenState createState() => _MembersScreenState();
+  State<MembersScreen> createState() => _MembersScreenState();
 }
 
 class _MembersScreenState extends State<MembersScreen> {

--- a/lib/ui/screens/profile_screen.dart
+++ b/lib/ui/screens/profile_screen.dart
@@ -22,7 +22,7 @@ class ProfileScreen extends StatefulWidget {
   ProfileScreen({required this.pk, this.member}) : super(key: ValueKey(pk));
 
   @override
-  _ProfileScreenState createState() => _ProfileScreenState();
+  State<ProfileScreen> createState() => _ProfileScreenState();
 }
 
 class _ProfileScreenState extends State<ProfileScreen> {
@@ -106,14 +106,12 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         final imagePath = pickedFile?.path;
                         if (imagePath == null) return;
                         final croppedFile = await ImageCropper().cropImage(
-                            sourcePath: imagePath,
-                            iosUiSettings: const IOSUiSettings(
-                              title: 'Crop',
-                            ),
-                            compressFormat: ImageCompressFormat.jpg);
+                          sourcePath: imagePath,
+                          uiSettings: [IOSUiSettings(title: 'Crop')],
+                          compressFormat: ImageCompressFormat.jpg,
+                        );
                         if (croppedFile == null) return;
                         final scaffoldMessenger = ScaffoldMessenger.of(context);
-                        // Not ThaliaRouterDelegate since this is a dialog.
                         Navigator.of(context).pop();
                         scaffoldMessenger.showSnackBar(const SnackBar(
                           behavior: SnackBarBehavior.floating,
@@ -163,15 +161,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                         if (imagePath == null) return;
                         final croppedFile = await ImageCropper().cropImage(
                           sourcePath: imagePath,
-                          iosUiSettings: const IOSUiSettings(
-                            title: 'Crop',
-                          ),
+                          uiSettings: [IOSUiSettings(title: 'Crop')],
                         );
                         if (croppedFile == null) return;
-                        final scaffoldMessenger = ScaffoldMessenger.of(
-                          context,
-                        );
-                        // Not ThaliaRouterDelegate since this is a dialog.
+                        final scaffoldMessenger = ScaffoldMessenger.of(context);
                         Navigator.of(context).pop();
                         scaffoldMessenger.showSnackBar(const SnackBar(
                           behavior: SnackBarBehavior.floating,
@@ -308,13 +301,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   if (imagePath == null) return;
                   final croppedFile = await ImageCropper().cropImage(
                       sourcePath: imagePath,
-                      iosUiSettings: const IOSUiSettings(
-                        title: 'Crop',
-                      ),
+                      uiSettings: [IOSUiSettings(title: 'Crop')],
                       compressFormat: ImageCompressFormat.jpg);
                   if (croppedFile == null) return;
                   final scaffoldMessenger = ScaffoldMessenger.of(context);
-                  // Not ThaliaRouterDelegate since this is a dialog.
                   scaffoldMessenger.showSnackBar(const SnackBar(
                     behavior: SnackBarBehavior.floating,
                     content: Text(
@@ -363,14 +353,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                   if (imagePath == null) return;
                   final croppedFile = await ImageCropper().cropImage(
                     sourcePath: imagePath,
-                    iosUiSettings: const IOSUiSettings(
-                      title: 'Crop',
-                    ),
+                    uiSettings: [IOSUiSettings(title: 'Crop')],
                   );
                   if (croppedFile == null) return;
-                  final scaffoldMessenger = ScaffoldMessenger.of(
-                    context,
-                  );
+                  final scaffoldMessenger = ScaffoldMessenger.of(context);
                   scaffoldMessenger.showSnackBar(const SnackBar(
                     behavior: SnackBarBehavior.floating,
                     content: Text(
@@ -473,10 +459,9 @@ class _ProfileScreenState extends State<ProfileScreen> {
         GestureDetector(
           onTap: member.website != null
               ? () async {
-                  await launch(
-                    member.website!.toString(),
-                    forceSafariVC: false,
-                    forceWebView: false,
+                  await launchUrl(
+                    member.website!,
+                    mode: LaunchMode.externalApplication,
                   );
                 }
               : null,

--- a/lib/ui/screens/registration_screen.dart
+++ b/lib/ui/screens/registration_screen.dart
@@ -15,7 +15,7 @@ class RegistrationScreen extends StatefulWidget {
       : super(key: ValueKey(registrationPk));
 
   @override
-  _RegistrationScreenState createState() => _RegistrationScreenState();
+  State<RegistrationScreen> createState() => _RegistrationScreenState();
 }
 
 class _RegistrationScreenState extends State<RegistrationScreen> {
@@ -95,7 +95,7 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
                               maxLines: 5,
                               decoration: InputDecoration(
                                 labelText: field.isRequired
-                                    ? field.label + ' *'
+                                    ? '${field.label} *'
                                     : field.label,
                                 hintText: 'Lorem ipsum...',
                               ),
@@ -134,7 +134,7 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
                               ],
                               decoration: InputDecoration(
                                 labelText: field.isRequired
-                                    ? field.label + ' *'
+                                    ? '${field.label} *'
                                     : field.label,
                                 hintText: '123...',
                               ),

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -299,10 +299,9 @@ class _AboutCard extends StatelessWidget {
             const SizedBox(height: 8),
             OutlinedButton.icon(
               onPressed: () async {
-                await launch(
-                  config.changelogUri.toString(),
-                  forceSafariVC: false,
-                  forceWebView: false,
+                await launchUrl(
+                  config.changelogUri,
+                  mode: LaunchMode.externalApplication,
                 );
               },
               icon: const Icon(Icons.history),
@@ -310,10 +309,9 @@ class _AboutCard extends StatelessWidget {
             ),
             OutlinedButton.icon(
               onPressed: () async {
-                await launch(
-                  config.feedbackUri.toString(),
-                  forceSafariVC: false,
-                  forceWebView: false,
+                await launchUrl(
+                  config.feedbackUri,
+                  mode: LaunchMode.externalApplication,
                 );
               },
               icon: const Icon(Icons.bug_report_outlined),

--- a/lib/ui/screens/welcome_screen.dart
+++ b/lib/ui/screens/welcome_screen.dart
@@ -19,7 +19,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 class WelcomeScreen extends StatefulWidget {
   @override
-  _WelcomeScreenState createState() => _WelcomeScreenState();
+  State<WelcomeScreen> createState() => _WelcomeScreenState();
 }
 
 class _WelcomeScreenState extends State<WelcomeScreen> {
@@ -68,10 +68,9 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                 return true;
               } else {
                 try {
-                  await launch(
-                    url,
-                    forceSafariVC: false,
-                    forceWebView: false,
+                  await launchUrl(
+                    Uri.parse(url),
+                    mode: LaunchMode.externalApplication,
                   );
                 } catch (_) {
                   ScaffoldMessenger.of(context).showSnackBar(SnackBar(
@@ -216,7 +215,7 @@ class SlidesCarousel extends StatefulWidget {
   }) : super(key: key);
 
   @override
-  _SlidesCarouselState createState() => _SlidesCarouselState();
+  State<SlidesCarousel> createState() => _SlidesCarouselState();
 }
 
 class _SlidesCarouselState extends State<SlidesCarousel> {
@@ -243,10 +242,9 @@ class _SlidesCarouselState extends State<SlidesCarousel> {
             return InkWell(
               onTap: slide.url != null
                   ? () async {
-                      await launch(
-                        slide.url.toString(),
-                        forceSafariVC: false,
-                        forceWebView: false,
+                      await launchUrl(
+                        slide.url!,
+                        mode: LaunchMode.externalApplication,
                       );
                     }
                   : null,

--- a/lib/ui/widgets/push_notification_dialog.dart
+++ b/lib/ui/widgets/push_notification_dialog.dart
@@ -36,11 +36,7 @@ class PushNotificationDialog extends StatelessWidget {
               if (isDeepLink(uri!)) {
                 context.go(Uri(path: uri.path, query: uri.query).toString());
               } else {
-                await launch(
-                  uri.toString(),
-                  forceSafariVC: false,
-                  forceWebView: false,
-                );
+                await launchUrl(uri, mode: LaunchMode.externalApplication);
               }
             },
             child: const Text('OPEN'),

--- a/lib/ui/widgets/push_notification_overlay.dart
+++ b/lib/ui/widgets/push_notification_overlay.dart
@@ -27,11 +27,7 @@ class PushNotificationOverlay extends StatelessWidget {
                       query: uri.query,
                     ).toString());
                   } else {
-                    await launch(
-                      uri.toString(),
-                      forceSafariVC: false,
-                      forceWebView: false,
-                    );
+                    await launchUrl(uri, mode: LaunchMode.externalApplication);
                   }
                 }
               : null,

--- a/lib/ui/widgets/tpay_sales_order_dialog.dart
+++ b/lib/ui/widgets/tpay_sales_order_dialog.dart
@@ -10,7 +10,7 @@ class TPaySalesOrderDialog extends StatefulWidget {
   TPaySalesOrderDialog({required this.pk}) : super(key: ValueKey(pk));
 
   @override
-  _TPaySalesOrderDialogState createState() => _TPaySalesOrderDialogState();
+  State<TPaySalesOrderDialog> createState() => _TPaySalesOrderDialogState();
 }
 
 class _TPaySalesOrderDialogState extends State<TPaySalesOrderDialog> {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "38.0.0"
+    version: "40.0.0"
   add_2_calendar:
     dependency: "direct main"
     description:
@@ -21,14 +21,14 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.4.1"
+    version: "4.1.0"
   animations:
     dependency: "direct main"
     description:
       name: animations
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.3"
   archive:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   async:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.3.0"
   build_config:
     dependency: transitive
     description:
@@ -84,21 +84,21 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.6"
+    version: "2.0.9"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.8"
+    version: "2.1.11"
   build_runner_core:
     dependency: transitive
     description:
@@ -119,14 +119,14 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.1.4"
+    version: "8.3.2"
   cached_network_image:
     dependency: "direct main"
     description:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.0"
+    version: "3.2.1"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: carousel_slider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.1"
   characters:
     dependency: transitive
     description:
@@ -184,47 +184,47 @@ packages:
     source: hosted
     version: "4.1.0"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   cross_file:
     dependency: transitive
     description:
       name: cross_file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2"
+    version: "0.3.3+1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   csslib:
     dependency: transitive
     description:
       name: csslib
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.1"
+    version: "0.17.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.2"
+    version: "2.2.3"
   equatable:
     dependency: "direct main"
     description:
@@ -238,14 +238,14 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   ffi:
     dependency: transitive
     description:
       name: ffi
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.1"
   file:
     dependency: transitive
     description:
@@ -259,49 +259,49 @@ packages:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.0"
+    version: "1.17.1"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.5"
+    version: "4.4.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.1"
+    version: "1.6.4"
   firebase_messaging:
     dependency: "direct main"
     description:
       name: firebase_messaging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "11.2.12"
+    version: "11.4.1"
   firebase_messaging_platform_interface:
     dependency: transitive
     description:
       name: firebase_messaging_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.2"
+    version: "3.5.1"
   firebase_messaging_web:
     dependency: transitive
     description:
       name: firebase_messaging_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.10"
+    version: "2.4.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -320,7 +320,7 @@ packages:
       name: flutter_blurhash
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.7.0"
   flutter_cache_manager:
     dependency: "direct main"
     description:
@@ -334,7 +334,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_native_splash:
     dependency: "direct dev"
     description:
@@ -348,7 +348,7 @@ packages:
       name: flutter_plugin_android_lifecycle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -414,21 +414,21 @@ packages:
       name: flutter_widget_from_html_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5+1"
+    version: "0.8.5+3"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   fwfh_text_style:
     dependency: transitive
     description:
       name: fwfh_text_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.3+1"
+    version: "2.7.3+2"
   gallery_saver:
     dependency: "direct main"
     description:
@@ -449,14 +449,14 @@ packages:
       name: go_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.7"
+    version: "3.1.1"
   google_fonts:
     dependency: "direct main"
     description:
       name: google_fonts
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "3.0.1"
   graphs:
     dependency: transitive
     description:
@@ -491,7 +491,7 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.1"
   image:
     dependency: transitive
     description:
@@ -505,42 +505,56 @@ packages:
       name: image_cropper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "2.0.3"
+  image_cropper_for_web:
+    dependency: transitive
+    description:
+      name: image_cropper_for_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
+  image_cropper_platform_interface:
+    dependency: transitive
+    description:
+      name: image_cropper_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   image_picker:
     dependency: "direct main"
     description:
       name: image_picker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.5"
+    version: "0.8.5+3"
   image_picker_android:
     dependency: transitive
     description:
       name: image_picker_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+11"
+    version: "0.8.4+13"
   image_picker_for_web:
     dependency: transitive
     description:
       name: image_picker_for_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.6"
+    version: "2.1.8"
   image_picker_ios:
     dependency: transitive
     description:
       name: image_picker_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.8.4+11"
+    version: "0.8.5+5"
   image_picker_platform_interface:
     dependency: transitive
     description:
       name: image_picker_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.4"
+    version: "2.5.0"
   intl:
     dependency: "direct main"
     description:
@@ -561,28 +575,28 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "4.5.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.5"
+    version: "6.2.0"
   lints:
     dependency: transitive
     description:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.0"
   logging:
     dependency: transitive
     description:
@@ -603,7 +617,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: "direct main"
     description:
@@ -617,7 +631,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   nested:
     dependency: transitive
     description:
@@ -638,14 +652,14 @@ packages:
       name: octo_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   overlay_support:
     dependency: "direct main"
     description:
       name: overlay_support
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "2.0.0"
   package_config:
     dependency: transitive
     description:
@@ -701,56 +715,56 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: "direct main"
     description:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.10"
   path_provider_android:
     dependency: transitive
     description:
       name: path_provider_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.12"
+    version: "2.0.14"
   path_provider_ios:
     dependency: transitive
     description:
       name: path_provider_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
+    version: "2.0.9"
   path_provider_linux:
     dependency: transitive
     description:
       name: path_provider_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "2.1.7"
   path_provider_macos:
     dependency: transitive
     description:
       name: path_provider_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.6"
   path_provider_platform_interface:
     dependency: transitive
     description:
       name: path_provider_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   path_provider_windows:
     dependency: transitive
     description:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.0.7"
   pedantic:
     dependency: transitive
     description:
@@ -764,7 +778,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "5.0.0"
   photo_view:
     dependency: "direct main"
     description:
@@ -806,7 +820,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.2"
+    version: "6.0.3"
   pub_semver:
     dependency: transitive
     description:
@@ -827,28 +841,28 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.27.3"
+    version: "0.27.4"
   sentry:
     dependency: transitive
     description:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.4.0"
+    version: "6.5.1"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.4.0"
+    version: "6.5.1"
   share_plus:
     dependency: "direct main"
     description:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.3"
+    version: "4.0.5"
   share_plus_linux:
     dependency: transitive
     description:
@@ -862,63 +876,63 @@ packages:
       name: share_plus_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.3"
   share_plus_web:
     dependency: transitive
     description:
       name: share_plus_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   share_plus_windows:
     dependency: transitive
     description:
       name: share_plus_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   shared_preferences:
     dependency: "direct main"
     description:
       name: shared_preferences
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.13"
+    version: "2.0.15"
   shared_preferences_android:
     dependency: transitive
     description:
       name: shared_preferences_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.11"
+    version: "2.0.12"
   shared_preferences_ios:
     dependency: transitive
     description:
       name: shared_preferences_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   shared_preferences_linux:
     dependency: transitive
     description:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   shared_preferences_macos:
     dependency: transitive
     description:
       name: shared_preferences_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   shared_preferences_platform_interface:
     dependency: transitive
     description:
@@ -932,14 +946,14 @@ packages:
       name: shared_preferences_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.0.4"
   shared_preferences_windows:
     dependency: transitive
     description:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:
@@ -965,35 +979,35 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   source_helper:
     dependency: transitive
     description:
       name: source_helper
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.2"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   sqflite:
     dependency: transitive
     description:
       name: sqflite
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.2+1"
   sqflite_common:
     dependency: transitive
     description:
       name: sqflite_common
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.2.1+1"
   stack_trace:
     dependency: transitive
     description:
@@ -1007,7 +1021,7 @@ packages:
       name: sticky_headers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.0"
+    version: "0.3.0+2"
   stream_channel:
     dependency: transitive
     description:
@@ -1049,7 +1063,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.9"
   timing:
     dependency: transitive
     description:
@@ -1063,7 +1077,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   universal_io:
     dependency: transitive
     description:
@@ -1077,35 +1091,35 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.20"
+    version: "6.1.2"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.15"
+    version: "6.0.17"
   url_launcher_ios:
     dependency: transitive
     description:
       name: url_launcher_ios
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.15"
+    version: "6.0.17"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   url_launcher_platform_interface:
     dependency: transitive
     description:
@@ -1119,14 +1133,14 @@ packages:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.0.11"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   uuid:
     dependency: transitive
     description:
@@ -1140,7 +1154,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   watcher:
     dependency: transitive
     description:
@@ -1154,14 +1168,14 @@ packages:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   win32:
     dependency: transitive
     description:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.1"
+    version: "2.6.1"
   xdg_directories:
     dependency: transitive
     description:
@@ -1175,14 +1189,14 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.1"
+    version: "5.4.1"
   yaml:
     dependency: transitive
     description:
       name: yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
 sdks:
-  dart: ">=2.16.0 <3.0.0"
-  flutter: ">=2.10.0"
+  dart: ">=2.17.0 <3.0.0"
+  flutter: ">=3.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -451,7 +451,7 @@ packages:
       name: go_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "4.0.0"
   google_fonts:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -399,9 +399,11 @@ packages:
   flutter_web_auth:
     dependency: "direct main"
     description:
-      name: flutter_web_auth
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "."
+      ref: a49488592f9eeeec3c75ae9335ed51ae84f2a2b0
+      resolved-ref: a49488592f9eeeec3c75ae9335ed51ae84f2a2b0
+      url: "https://github.com/noga-dev/flutter_web_auth.git"
+    source: git
     version: "0.4.1"
   flutter_web_plugins:
     dependency: transitive

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,7 +59,13 @@ dependencies:
   url_launcher: ^6.0.11
 
   # Authenticating in browser.
-  flutter_web_auth: ^0.4.0
+  flutter_web_auth:
+    # flutter_web_auth is not compatible with flutter 3.0.x yet. The fix has not 
+    # been released yet, so we temporarily reference the fix by a git reference.
+    # TODO: Remove this when the fix is released. See: https://github.com/LinusU/flutter_web_auth/pull/118
+    git:
+      url: https://github.com/noga-dev/flutter_web_auth.git
+      ref: a49488592f9eeeec3c75ae9335ed51ae84f2a2b0
 
   # Modal photo views.
   photo_view: ^0.14.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -113,7 +113,7 @@ dependencies:
   flutter_cache_manager: ^3.3.0
 
   # Navigation.
-  go_router: ^3.0.1
+  go_router: ^4.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,8 +26,11 @@ dependencies:
   # Annotations.
   meta: ^1.7.0
 
+  # Nice functions for collections.
+  collection: ^1.16.0
+
   # Fonts.
-  google_fonts: ^2.1.0
+  google_fonts: ^3.0.1
 
   # DateTime formatting.
   intl: ^0.17.0
@@ -65,7 +68,7 @@ dependencies:
   flutter_widget_from_html_core: ^0.8.4
 
   # Sentry error reporting.
-  sentry_flutter: ^6.3.0
+  sentry_flutter: ^6.5.1
 
   # Share menu.
   share_plus: ^4.0.3
@@ -78,7 +81,7 @@ dependencies:
   gallery_saver: ^2.3.2
 
   # Resize images.
-  image_cropper: ^1.4.1
+  image_cropper: ^2.0.3
 
   # Carousel.
   carousel_slider: ^4.0.0
@@ -88,20 +91,20 @@ dependencies:
   firebase_messaging: ^11.2.6
 
   # Push notifications in app. 
-  overlay_support: ^1.2.1
+  overlay_support: ^2.0.0
 
   # Sticky headers for calendar.
-  sticky_headers: ^0.2.0
+  sticky_headers: ^0.3.0
 
   # Predefined animations.
-  animations: ^2.0.2
+  animations: ^2.0.3
 
   # Export event to calendar.
   add_2_calendar: ^2.1.3
 
   # Cached images.
-  cached_network_image: ^3.1.0
-  flutter_cache_manager: ^3.1.2
+  cached_network_image: ^3.2.1
+  flutter_cache_manager: ^3.3.0
 
   # Navigation.
   go_router: ^3.0.1
@@ -117,7 +120,7 @@ dev_dependencies:
   json_serializable: ^6.1.3
 
   # Linting.
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
   # Generating splash screens.
   flutter_native_splash: ^1.2.3


### PR DESCRIPTION
Closes #225.

This updates dependencies and refactors some code to adhere to new `flutter_lints` rules.

`flutter_web_auth` has a fix for compatibility that still hasn't been released. It is used through a git reference, like we did in #207. This will also need to be reverted some day.