### PR TITLE
Fix gallery backbutton

### DIFF
--- a/lib/blocs/album_cubit.dart
+++ b/lib/blocs/album_cubit.dart
@@ -1,143 +1,61 @@
-import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:meta/meta.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
-typedef AlbumState = DetailState<Album>;
+class OpenGalleryState extends ResultState<Album> {
+  final int initialGalleryIndex;
 
-class AlbumScreenState extends Equatable {
-  /// This can only be null when [isLoading] or [hasException] is true.
-  final Album? album;
-  final bool isOpen;
-  final int? initialGalleryIndex;
-
-  final String? message;
-  final bool isLoading;
-  bool get hasException => message != null;
-
-  @protected
-  const AlbumScreenState({
-    required this.album,
-    required this.isLoading,
-    required this.message,
-    this.isOpen = false,
-    this.initialGalleryIndex,
-  })  : assert(
-          album != null || isLoading || message != null,
-          'album can only be null when isLoading or hasException is true.',
-        ),
-        assert(
-          isOpen || initialGalleryIndex == null,
-          'initialGalleryIndex can only be set when isOpen is true.',
-        ),
-        assert(
-          initialGalleryIndex != null || !isOpen,
-          'initialGalleryIndex must be set when isOpen is true.',
-        ),
-        assert(
-          !isOpen || album != null,
-          'album must be set when isOpen is true.',
-        );
-
-  @override
-  List<Object?> get props => [
-        album,
-        message,
-        isLoading,
-        isOpen,
-        initialGalleryIndex,
-      ];
-
-  AlbumScreenState copyWith({
-    Album? album,
-    List<AdminEventRegistration>? registrations,
-    bool? isLoading,
-    String? message,
-    bool? isOpen,
-    int? initialGalleryIndex,
-  }) =>
-      AlbumScreenState(
-        album: album ?? this.album,
-        isLoading: isLoading ?? this.isLoading,
-        message: message ?? this.message,
-        isOpen: isOpen ?? this.isOpen,
-        initialGalleryIndex: (isOpen ?? this.isOpen)
-            ? (initialGalleryIndex ?? this.initialGalleryIndex)
-            : null,
-      );
-
-  const AlbumScreenState.result(
-      {required this.album, required this.isOpen, this.initialGalleryIndex})
-      : message = null,
-        isLoading = false;
-
-  const AlbumScreenState.loading()
-      : message = null,
-        album = null,
-        isLoading = true,
-        isOpen = false,
-        initialGalleryIndex = null;
-
-  const AlbumScreenState.failure({required String this.message})
-      : album = null,
-        isLoading = false,
-        isOpen = false,
-        initialGalleryIndex = null;
+  OpenGalleryState(Album result, this.initialGalleryIndex) : super(result);
 }
 
-class AlbumCubit extends Cubit<AlbumScreenState> {
+class AlbumCubit extends Cubit<XDetailState<Album>> {
   final ApiRepository api;
 
-  AlbumCubit(this.api) : super(const AlbumScreenState.loading());
+  AlbumCubit(this.api) : super(const LoadingState());
 
   Future<void> updateLike({required bool liked, required int index}) async {
-    if (state.album == null) {
-      return;
-    }
+    if (state is! ResultState) return;
+    final oldState = state as ResultState<Album>;
+    final oldPhoto = oldState.result.photos[index];
+    if (oldPhoto.liked == liked) return;
 
     // Emit expected state after (un)liking.
-    final oldphoto = state.album!.photos[index];
-    AlbumPhoto newphoto = oldphoto.copyWith(
+    AlbumPhoto newphoto = oldPhoto.copyWith(
       liked: liked,
-      numLikes: oldphoto.numLikes + (liked ? 1 : -1),
+      numLikes: oldPhoto.numLikes + (liked ? 1 : -1),
     );
-    List<AlbumPhoto> newphotos = [...state.album!.photos];
+    List<AlbumPhoto> newphotos = [...oldState.result.photos];
     newphotos[index] = newphoto;
-    emit(AlbumScreenState.result(
-      album: state.album!.copyWith(photos: newphotos),
-      isOpen: state.isOpen,
-      initialGalleryIndex: state.initialGalleryIndex,
+    emit(ResultState(
+      oldState.result.copyWith(photos: newphotos),
     ));
 
     try {
       await api.updateLiked(newphoto.pk, liked);
     } on ApiException {
       // Revert to state before (un)liking.
-      emit(state);
+      emit(oldState);
       rethrow;
     }
   }
 
   void openGallery(int index) {
-    if (state.album == null) return;
-    emit(state.copyWith(isOpen: true, initialGalleryIndex: index));
-  }
-
-  void closeGallery() {
-    emit(state.copyWith(isOpen: false));
+    if (state is! ResultState) return;
+    final oldState = state as ResultState<Album>;
+    emit(OpenGalleryState(oldState.result, index));
+    emit(oldState);
   }
 
   Future<void> load(String slug) async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final album = await api.getAlbum(slug: slug);
-      emit(AlbumScreenState.result(album: album, isOpen: false));
+      emit(ResultState(album));
     } on ApiException catch (exception) {
-      emit(AlbumScreenState.failure(
-        message: exception.getMessage(notFound: 'The album does not exist.'),
+      emit(ErrorState(
+        exception.getMessage(notFound: 'The album does not exist.'),
       ));
     }
   }

--- a/lib/blocs/album_cubit.dart
+++ b/lib/blocs/album_cubit.dart
@@ -4,7 +4,9 @@ import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
-class AlbumCubit extends Cubit<XDetailState<Album>> {
+typedef AlbumState = DetailState<Album>;
+
+class AlbumCubit extends Cubit<AlbumState> {
   final ApiRepository api;
 
   AlbumCubit(this.api) : super(const LoadingState());

--- a/lib/blocs/album_cubit.dart
+++ b/lib/blocs/album_cubit.dart
@@ -4,12 +4,6 @@ import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
-class OpenGalleryState extends ResultState<Album> {
-  final int initialGalleryIndex;
-
-  OpenGalleryState(Album result, this.initialGalleryIndex) : super(result);
-}
-
 class AlbumCubit extends Cubit<XDetailState<Album>> {
   final ApiRepository api;
 
@@ -39,13 +33,6 @@ class AlbumCubit extends Cubit<XDetailState<Album>> {
       emit(oldState);
       rethrow;
     }
-  }
-
-  void openGallery(int index) {
-    if (state is! ResultState) return;
-    final oldState = state as ResultState<Album>;
-    emit(OpenGalleryState(oldState.result, index));
-    emit(oldState);
   }
 
   Future<void> load(String slug) async {

--- a/lib/blocs/detail_state.dart
+++ b/lib/blocs/detail_state.dart
@@ -54,3 +54,74 @@ class DetailState<E> extends Equatable {
       : result = null,
         isLoading = false;
 }
+
+/// Generic type for states with a single result.
+///
+/// There are a number of subtypes:
+/// * [ResultState] - indicates that there is a result.
+/// * [LoadingState] - indicates that we are loading.
+/// * [ErrorState] - indicates that there is an error.
+///
+/// Additionally there are:
+/// * [LoadingResultState] - indicates that there is a result and we are loading.
+///   This is a subtype of both [ResultState] and [LoadingState].
+/// * [LoadingErrorState] - indicates that there is an error and we are loading.
+///   This is a subtype of both [ErrorState] and [LoadingState]
+///
+/// Additional subtypes can be added as needed.
+abstract class XDetailState<T> {
+  const XDetailState();
+
+  T? get result => this is ResultState ? (this as ResultState<T>).result : null;
+  String? get message =>
+      this is ErrorState ? (this as ErrorState<T>).message : null;
+}
+
+/// A generic state that indicates that there is a result.
+///
+/// A subtype is [LoadingResultState] which indicates that we are also loading.
+class ResultState<T> extends XDetailState<T> {
+  @override
+  final T result;
+
+  const ResultState(this.result);
+}
+
+/// A generic state that indicates that there is an error.
+///
+/// A subtype is [LoadingErrorState] which indicates that we are also loading.
+class ErrorState<T> extends XDetailState<T> {
+  @override
+  final String message;
+
+  const ErrorState(this.message);
+}
+
+/// A generic state that indicates that we are loading.
+///
+/// This is also implemented by [LoadingResultState] and [LoadingErrorState],
+/// which also indicate that there is a result or an error.
+///
+/// [LoadingState.from] can be used to convert any state into either a
+/// [LoadingState] or the right subtype of it.
+class LoadingState<T> extends XDetailState<T> {
+  const LoadingState();
+
+  factory LoadingState.from(XDetailState<T> state) {
+    if (state is ResultState<T>) {
+      return LoadingResultState(state.result);
+    } else if (state is ErrorState<T>) {
+      return LoadingErrorState(state.message);
+    } else {
+      return const LoadingState();
+    }
+  }
+}
+
+class LoadingResultState<T> extends ResultState<T> implements LoadingState<T> {
+  const LoadingResultState(T result) : super(result);
+}
+
+class LoadingErrorState<T> extends ErrorState<T> implements LoadingState<T> {
+  const LoadingErrorState(String message) : super(message);
+}

--- a/lib/blocs/detail_state.dart
+++ b/lib/blocs/detail_state.dart
@@ -69,7 +69,7 @@ class DetailState<E> extends Equatable {
 ///   This is a subtype of both [ErrorState] and [LoadingState]
 ///
 /// Additional subtypes can be added as needed.
-abstract class XDetailState<T> {
+abstract class XDetailState<T> extends Equatable {
   const XDetailState();
 
   T? get result => this is ResultState ? (this as ResultState<T>).result : null;
@@ -85,6 +85,9 @@ class ResultState<T> extends XDetailState<T> {
   final T result;
 
   const ResultState(this.result);
+
+  @override
+  List<Object?> get props => [result];
 }
 
 /// A generic state that indicates that there is an error.
@@ -95,6 +98,9 @@ class ErrorState<T> extends XDetailState<T> {
   final String message;
 
   const ErrorState(this.message);
+
+  @override
+  List<Object?> get props => [message];
 }
 
 /// A generic state that indicates that we are loading.
@@ -116,12 +122,17 @@ class LoadingState<T> extends XDetailState<T> {
       return const LoadingState();
     }
   }
+
+  @override
+  List<Object?> get props => [];
 }
 
+/// A generic state that indicates that we are loading and there is a result.
 class LoadingResultState<T> extends ResultState<T> implements LoadingState<T> {
   const LoadingResultState(T result) : super(result);
 }
 
+/// A generic state that indicates that we are loading and there is an error.
 class LoadingErrorState<T> extends ErrorState<T> implements LoadingState<T> {
   const LoadingErrorState(String message) : super(message);
 }

--- a/lib/blocs/detail_state.dart
+++ b/lib/blocs/detail_state.dart
@@ -1,59 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:meta/meta.dart';
-
-/// Generic class to be used as state when loading
-class DetailState<E> extends Equatable {
-  /// The result to be shown.
-  ///
-  /// This can only be null when [isLoading] or [hasException] is true.
-  final E? result;
-
-  /// A message describing why there are no results.
-  final String? message;
-
-  /// A result is being loaded. If there already is a result, it is outdated.
-  final bool isLoading;
-
-  bool get hasException => message != null;
-
-  @protected
-  const DetailState({
-    required this.result,
-    required this.isLoading,
-    required this.message,
-  }) : assert(
-          result != null || isLoading || message != null,
-          'result can only be null when isLoading or hasException is true.',
-        );
-
-  @override
-  List<Object?> get props => [result, message, isLoading];
-
-  @override
-  String toString() {
-    return 'DetailState<$E>(result: $result, '
-        'loading: $isLoading, message: $message)';
-  }
-
-  DetailState<E> copyWith({E? result, bool? isLoading, String? message}) =>
-      DetailState<E>(
-        result: result ?? this.result,
-        isLoading: isLoading ?? this.isLoading,
-        message: message ?? this.message,
-      );
-
-  const DetailState.result({required E this.result})
-      : message = null,
-        isLoading = false;
-
-  const DetailState.loading({this.result})
-      : message = null,
-        isLoading = true;
-
-  const DetailState.failure({required String this.message})
-      : result = null,
-        isLoading = false;
-}
 
 /// Generic type for states with a single result.
 ///
@@ -69,8 +14,8 @@ class DetailState<E> extends Equatable {
 ///   This is a subtype of both [ErrorState] and [LoadingState]
 ///
 /// Additional subtypes can be added as needed.
-abstract class XDetailState<T> extends Equatable {
-  const XDetailState();
+abstract class DetailState<T> extends Equatable {
+  const DetailState();
 
   T? get result => this is ResultState ? (this as ResultState<T>).result : null;
   String? get message =>
@@ -80,7 +25,7 @@ abstract class XDetailState<T> extends Equatable {
 /// A generic state that indicates that there is a result.
 ///
 /// A subtype is [LoadingResultState] which indicates that we are also loading.
-class ResultState<T> extends XDetailState<T> {
+class ResultState<T> extends DetailState<T> {
   @override
   final T result;
 
@@ -93,7 +38,7 @@ class ResultState<T> extends XDetailState<T> {
 /// A generic state that indicates that there is an error.
 ///
 /// A subtype is [LoadingErrorState] which indicates that we are also loading.
-class ErrorState<T> extends XDetailState<T> {
+class ErrorState<T> extends DetailState<T> {
   @override
   final String message;
 
@@ -110,10 +55,10 @@ class ErrorState<T> extends XDetailState<T> {
 ///
 /// [LoadingState.from] can be used to convert any state into either a
 /// [LoadingState] or the right subtype of it.
-class LoadingState<T> extends XDetailState<T> {
+class LoadingState<T> extends DetailState<T> {
   const LoadingState();
 
-  factory LoadingState.from(XDetailState<T> state) {
+  factory LoadingState.from(DetailState<T> state) {
     if (state is ResultState<T>) {
       return LoadingResultState(state.result);
     } else if (state is ErrorState<T>) {

--- a/lib/blocs/event_cubit.dart
+++ b/lib/blocs/event_cubit.dart
@@ -12,18 +12,17 @@ class EventCubit extends Cubit<EventState> {
 
   // TODO: Someday: combine with RegistrationsCubit.
 
-  EventCubit(this.api, {required this.eventPk})
-      : super(const EventState.loading());
+  EventCubit(this.api, {required this.eventPk}) : super(const LoadingState());
 
   Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final event = await api.getEvent(pk: eventPk);
-      emit(EventState.result(result: event));
+      emit(ResultState(event));
     } on ApiException catch (exception) {
-      emit(EventState.failure(
-        message: exception.getMessage(notFound: 'The event does not exist.'),
-      ));
+      emit(ErrorState(exception.getMessage(
+        notFound: 'The event does not exist.',
+      )));
     }
   }
 

--- a/lib/blocs/full_member_cubit.dart
+++ b/lib/blocs/full_member_cubit.dart
@@ -11,19 +11,19 @@ typedef FullMemberState = DetailState<FullMember>;
 class FullMemberCubit extends Cubit<FullMemberState> {
   final ApiRepository api;
 
-  FullMemberCubit(this.api) : super(const FullMemberState.loading());
+  FullMemberCubit(this.api) : super(const LoadingState());
 
   Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final member = await api.getMe();
       // Set username for sentry.
       Sentry.configureScope(
         (scope) => scope.setUser(SentryUser(username: member.displayName)),
       );
-      emit(FullMemberState.result(result: member));
+      emit(ResultState(member));
     } on ApiException catch (exception) {
-      emit(FullMemberState.failure(message: exception.message));
+      emit(ErrorState(exception.message));
     }
   }
 

--- a/lib/blocs/group_cubit.dart
+++ b/lib/blocs/group_cubit.dart
@@ -14,20 +14,18 @@ class GroupCubit extends Cubit<GroupState> implements BaseGroupCubit {
   final ApiRepository api;
   final int pk;
 
-  GroupCubit(this.api, {required this.pk}) : super(const GroupState.loading());
+  GroupCubit(this.api, {required this.pk}) : super(const LoadingState());
 
   @override
   Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final group = await api.getGroup(pk: pk);
-      emit(DetailState.result(result: group));
+      emit(ResultState(group));
     } on ApiException catch (exception) {
-      emit(DetailState.failure(
-        message: exception.getMessage(
-          notFound: 'The group does not exist.',
-        ),
-      ));
+      emit(ErrorState(exception.getMessage(
+        notFound: 'The group does not exist.',
+      )));
     }
   }
 }
@@ -38,20 +36,18 @@ class BoardCubit extends Cubit<GroupState> implements BaseGroupCubit {
   final int until;
 
   BoardCubit(this.api, {required this.since, required this.until})
-      : super(const GroupState.loading());
+      : super(const LoadingState());
 
   @override
   Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final group = await api.getBoardGroup(since: since, until: until);
-      emit(DetailState.result(result: group));
+      emit(ResultState(group));
     } on ApiException catch (exception) {
-      emit(DetailState.failure(
-        message: exception.getMessage(
-          notFound: 'The group does not exist.',
-        ),
-      ));
+      emit(ErrorState(exception.getMessage(
+        notFound: 'The group does not exist.',
+      )));
     }
   }
 }

--- a/lib/blocs/groups_cubit.dart
+++ b/lib/blocs/groups_cubit.dart
@@ -10,19 +10,19 @@ class GroupsCubit extends Cubit<GroupsState> {
   final ApiRepository api;
   final MemberGroupType? groupType;
 
-  GroupsCubit(this.api, this.groupType) : super(const GroupsState.loading());
+  GroupsCubit(this.api, this.groupType) : super(const LoadingState());
 
   Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final listResponse = await api.getGroups(limit: 1000, type: groupType);
       if (listResponse.results.isNotEmpty) {
-        emit(GroupsState.result(result: listResponse.results));
+        emit(ResultState(listResponse.results));
       } else {
-        emit(const GroupsState.failure(message: 'There are no boards.'));
+        emit(const ErrorState('There are no boards.'));
       }
     } on ApiException catch (exception) {
-      emit(GroupsState.failure(message: _failureMessage(exception)));
+      emit(ErrorState(_failureMessage(exception)));
     }
   }
 

--- a/lib/blocs/member_cubit.dart
+++ b/lib/blocs/member_cubit.dart
@@ -9,17 +9,17 @@ typedef MemberState = DetailState<Member>;
 class MemberCubit extends Cubit<MemberState> {
   final ApiRepository api;
 
-  MemberCubit(this.api) : super(const MemberState.loading());
+  MemberCubit(this.api) : super(const LoadingState());
 
   Future<void> load(int pk) async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final member = await api.getMember(pk: pk);
-      emit(MemberState.result(result: member));
+      emit(ResultState(member));
     } on ApiException catch (exception) {
-      emit(MemberState.failure(
-        message: exception.getMessage(notFound: 'The member does not exist.'),
-      ));
+      emit(ErrorState(exception.getMessage(
+        notFound: 'The member does not exist.',
+      )));
     }
   }
 }

--- a/lib/blocs/payment_user_cubit.dart
+++ b/lib/blocs/payment_user_cubit.dart
@@ -9,15 +9,15 @@ typedef PaymentUserState = DetailState<PaymentUser>;
 class PaymentUserCubit extends Cubit<PaymentUserState> {
   final ApiRepository api;
 
-  PaymentUserCubit(this.api) : super(const PaymentUserState.loading());
+  PaymentUserCubit(this.api) : super(const LoadingState());
 
   Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final paymentUser = await api.getPaymentUser();
-      emit(PaymentUserState.result(result: paymentUser));
+      emit(ResultState(paymentUser));
     } on ApiException catch (exception) {
-      emit(PaymentUserState.failure(message: exception.message));
+      emit(ErrorState(exception.message));
     }
   }
 }

--- a/lib/blocs/registration_fields_cubit.dart
+++ b/lib/blocs/registration_fields_cubit.dart
@@ -9,24 +9,21 @@ typedef RegistrationFieldsState = DetailState<Map<String, RegistrationField>>;
 class RegistrationFieldsCubit extends Cubit<RegistrationFieldsState> {
   final ApiRepository api;
 
-  RegistrationFieldsCubit(this.api)
-      : super(const RegistrationFieldsState.loading());
+  RegistrationFieldsCubit(this.api) : super(const LoadingState());
 
   Future<void> load({required int eventPk, required int registrationPk}) async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final fields = await api.getRegistrationFields(
         eventPk: eventPk,
         registrationPk: registrationPk,
       );
-      emit(RegistrationFieldsState.result(result: fields));
+      emit(ResultState(fields));
     } on ApiException catch (exception) {
-      emit(RegistrationFieldsState.failure(
-        message: exception.getMessage(
-          notFound: 'The registration does not '
-              'exist or does not have any fields.',
-        ),
-      ));
+      emit(ErrorState(exception.getMessage(
+        notFound: 'The registration does not '
+            'exist or does not have any fields.',
+      )));
     }
   }
 

--- a/lib/blocs/sales_order_cubit.dart
+++ b/lib/blocs/sales_order_cubit.dart
@@ -9,16 +9,16 @@ typedef SalesOrderState = DetailState<SalesOrder>;
 class SalesOrderCubit extends Cubit<SalesOrderState> {
   final ApiRepository api;
 
-  SalesOrderCubit(this.api) : super(const SalesOrderState.loading());
+  SalesOrderCubit(this.api) : super(const LoadingState());
 
   Future<void> load(String pk) async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final order = await api.claimSalesOrder(pk: pk);
-      emit(SalesOrderState.result(result: order));
+      emit(ResultState(order));
     } on ApiException catch (exception) {
-      emit(SalesOrderState.failure(
-        message: exception.getMessage(notFound: 'The order does not exist.'),
+      emit(ErrorState(
+        exception.getMessage(notFound: 'The order does not exist.'),
       ));
     }
   }

--- a/lib/tosti/blocs/home_cubit.dart
+++ b/lib/tosti/blocs/home_cubit.dart
@@ -10,10 +10,10 @@ typedef TostiHomeState = DetailState<List<TostiVenue>>;
 class TostiHomeCubit extends Cubit<TostiHomeState> {
   final TostiApiRepository api;
 
-  TostiHomeCubit(this.api) : super(const TostiHomeState.loading());
+  TostiHomeCubit(this.api) : super(const LoadingState());
 
   Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
+    emit(LoadingState.from(state));
     try {
       final venuesFuture = api.getVenues(limit: 99, isOrderVenue: true);
       final playersFuture = api.getPlayers(limit: 99);
@@ -41,9 +41,9 @@ class TostiHomeCubit extends Cubit<TostiHomeState> {
         return player != null ? venue.copyWithPlayer(player) : venue;
       }).toList();
 
-      emit(TostiHomeState.result(result: venues));
+      emit(ResultState(venues));
     } on ApiException catch (exception) {
-      emit(TostiHomeState.failure(message: exception.message));
+      emit(ErrorState(exception.message));
     }
   }
 }

--- a/lib/tosti/tosti_screen.dart
+++ b/lib/tosti/tosti_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reaxit/blocs/detail_state.dart';
 import 'package:reaxit/tosti/blocs/auth_cubit.dart';
 import 'package:reaxit/tosti/blocs/home_cubit.dart';
 import 'package:reaxit/tosti/widgets/venue_card.dart';
@@ -103,9 +104,8 @@ class _SignedInTostiHomeView extends StatelessWidget {
     return RefreshIndicator(
       onRefresh: () => BlocProvider.of<TostiHomeCubit>(context).load(),
       child: BlocBuilder<TostiHomeCubit, TostiHomeState>(
-        buildWhen: (previous, current) => !current.isLoading,
         builder: (context, state) {
-          if (state.isLoading) {
+          if (state is LoadingState) {
             return ListView(
               physics: const AlwaysScrollableScrollPhysics(),
               children: const [
@@ -117,7 +117,7 @@ class _SignedInTostiHomeView extends StatelessWidget {
                 )
               ],
             );
-          } else if (state.hasException) {
+          } else if (state is ErrorState) {
             return ErrorScrollView(state.message!);
           } else if (state.result!.isEmpty) {
             return const ErrorScrollView('There are no venues.');

--- a/lib/ui/screens/album_screen.dart
+++ b/lib/ui/screens/album_screen.dart
@@ -67,30 +67,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
   Widget build(BuildContext context) {
     return BlocProvider.value(
       value: _cubit,
-      child: BlocConsumer<AlbumCubit, XDetailState<Album>>(
-        listenWhen: (previous, current) => current is OpenGalleryState,
-        listener: (context, state) {
-          final initialPage = (state as OpenGalleryState).initialGalleryIndex;
-          showDialog(
-            context: context,
-            useSafeArea: false,
-            barrierColor: Colors.black.withOpacity(0.92),
-            builder: (context) {
-              return BlocProvider.value(
-                value: _cubit,
-                child: BlocBuilder<AlbumCubit, XDetailState<Album>>(
-                  buildWhen: (previous, current) => current is ResultState,
-                  builder: (context, state) {
-                    return _Gallery(
-                      album: state.result!,
-                      initialPage: initialPage,
-                    );
-                  },
-                ),
-              );
-            },
-          );
-        },
+      child: BlocBuilder<AlbumCubit, XDetailState<Album>>(
         builder: (context, state) {
           late final Widget body;
           if (state is ResultState) {
@@ -357,6 +334,29 @@ class _PhotoGrid extends StatelessWidget {
 
   const _PhotoGrid(this.photos);
 
+  void _openGallery(BuildContext context, int index) {
+    final cubit = BlocProvider.of<AlbumCubit>(context);
+    showDialog(
+      context: context,
+      useSafeArea: false,
+      barrierColor: Colors.black.withOpacity(0.92),
+      builder: (context) {
+        return BlocProvider.value(
+          value: cubit,
+          child: BlocBuilder<AlbumCubit, XDetailState<Album>>(
+            buildWhen: (previous, current) => current is ResultState,
+            builder: (context, state) {
+              return _Gallery(
+                album: state.result!,
+                initialPage: index,
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scrollbar(
@@ -372,8 +372,7 @@ class _PhotoGrid extends StatelessWidget {
         padding: const EdgeInsets.all(8),
         itemBuilder: (context, index) => _PhotoTile(
           photo: photos[index],
-          openGallery: () =>
-              BlocProvider.of<AlbumCubit>(context).openGallery(index),
+          openGallery: () => _openGallery(context, index),
         ),
       ),
     );

--- a/lib/ui/screens/album_screen.dart
+++ b/lib/ui/screens/album_screen.dart
@@ -67,7 +67,7 @@ class _AlbumScreenState extends State<AlbumScreen> {
   Widget build(BuildContext context) {
     return BlocProvider.value(
       value: _cubit,
-      child: BlocBuilder<AlbumCubit, XDetailState<Album>>(
+      child: BlocBuilder<AlbumCubit, AlbumState>(
         builder: (context, state) {
           late final Widget body;
           if (state is ResultState) {
@@ -343,10 +343,11 @@ class _PhotoGrid extends StatelessWidget {
       builder: (context) {
         return BlocProvider.value(
           value: cubit,
-          child: BlocBuilder<AlbumCubit, XDetailState<Album>>(
+          child: BlocBuilder<AlbumCubit, AlbumState>(
             buildWhen: (previous, current) => current is ResultState,
             builder: (context, state) {
               return _Gallery(
+                // TODO: buildWhen actually does not guarantee not building without result.
                 album: state.result!,
                 initialPage: index,
               );

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -891,7 +891,7 @@ class _EventScreenState extends State<EventScreen> {
     return BlocBuilder<EventCubit, EventState>(
       bloc: _eventCubit,
       builder: (context, state) {
-        if (state.hasException) {
+        if (state is ErrorState) {
           return Scaffold(
             appBar: ThaliaAppBar(
               title: Text(widget.event?.title.toUpperCase() ?? 'EVENT'),
@@ -906,9 +906,9 @@ class _EventScreenState extends State<EventScreen> {
               child: ErrorScrollView(state.message!),
             ),
           );
-        } else if (state.isLoading &&
-            widget.event == null &&
-            state.result == null) {
+        } else if (state is LoadingState &&
+            state is! ResultState &&
+            widget.event == null) {
           return Scaffold(
             appBar: ThaliaAppBar(
               title: const Text('EVENT'),

--- a/lib/ui/screens/food_admin_screen.dart
+++ b/lib/ui/screens/food_admin_screen.dart
@@ -62,9 +62,9 @@ class _FoodAdminScreenState extends State<FoodAdminScreen> {
               },
               child: BlocBuilder<FoodAdminCubit, FoodAdminState>(
                 builder: (context, state) {
-                  if (state.hasException) {
+                  if (state is ErrorState) {
                     return ErrorScrollView(state.message!);
-                  } else if (state.isLoading) {
+                  } else if (state is LoadingState) {
                     return const Center(child: CircularProgressIndicator());
                   } else {
                     return Scrollbar(
@@ -249,9 +249,9 @@ class FoodAdminSearchDelegate extends SearchDelegate {
       value: _adminCubit..search(query),
       child: BlocBuilder<FoodAdminCubit, FoodAdminState>(
         builder: (context, state) {
-          if (state.hasException) {
+          if (state is ErrorState) {
             return ErrorScrollView(state.message!);
-          } else if (state.isLoading) {
+          } else if (state is LoadingState) {
             return const SizedBox.shrink();
           } else {
             return ListView.separated(
@@ -274,9 +274,9 @@ class FoodAdminSearchDelegate extends SearchDelegate {
       value: _adminCubit..search(query),
       child: BlocBuilder<FoodAdminCubit, FoodAdminState>(
         builder: (context, state) {
-          if (state.hasException) {
+          if (state is ErrorState) {
             return ErrorScrollView(state.message!);
-          } else if (state.isLoading) {
+          } else if (state is LoadingState) {
             return const SizedBox.shrink();
           } else {
             return ListView.separated(

--- a/lib/ui/screens/food_screen.dart
+++ b/lib/ui/screens/food_screen.dart
@@ -416,10 +416,9 @@ class __ProductTileState extends State<_ProductTile> {
           ? Text(widget.product.description)
           : null,
       trailing: BlocBuilder<FoodCubit, FoodState>(
-        buildWhen: (previous, current) => current.foodEvent != null,
         builder: (context, state) {
           return ElevatedButton(
-            onPressed: state.foodEvent!.canOrder()
+            onPressed: state.foodEvent?.canOrder() ?? false
                 ? () {
                     if (state.foodEvent!.hasOrder) {
                       _changeOrder(state.foodEvent!);

--- a/lib/ui/screens/group_screen.dart
+++ b/lib/ui/screens/group_screen.dart
@@ -72,7 +72,7 @@ class _Page extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (state.hasException) {
+    if (state is ErrorState) {
       return Scaffold(
         appBar: ThaliaAppBar(
           title: Text(listGroup?.name.toUpperCase() ?? 'GROUP'),
@@ -82,12 +82,16 @@ class _Page extends StatelessWidget {
           child: ErrorScrollView(state.message!),
         ),
       );
-    } else if (state.isLoading && listGroup == null && state.result == null) {
+    } else if (state is LoadingState &&
+        state is! ResultState &&
+        listGroup == null) {
       return Scaffold(
         appBar: ThaliaAppBar(title: const Text('GROUP')),
         body: const Center(child: CircularProgressIndicator()),
       );
-    } else if (state.isLoading && listGroup != null && state.result == null) {
+    } else if (state is LoadingState &&
+        state is! ResultState &&
+        listGroup != null) {
       final group = listGroup!;
       return Scaffold(
         appBar: ThaliaAppBar(title: Text(group.name.toUpperCase())),

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reaxit/blocs/detail_state.dart';
 import 'package:reaxit/blocs/groups_cubit.dart';
 import 'package:reaxit/models/group.dart';
 import 'package:reaxit/ui/widgets.dart';
@@ -74,9 +75,9 @@ class _GroupsScreenState extends State<GroupsScreen>
         children: [
           BlocBuilder<CommitteesCubit, GroupsState>(
             builder: (context, state) {
-              if (state.hasException) {
+              if (state is ErrorState) {
                 return ErrorScrollView(state.message!);
-              } else if (state.isLoading) {
+              } else if (state is LoadingState) {
                 return const Padding(
                   padding: EdgeInsets.all(16),
                   child: Center(child: CircularProgressIndicator()),
@@ -88,9 +89,9 @@ class _GroupsScreenState extends State<GroupsScreen>
           ),
           BlocBuilder<SocietiesCubit, GroupsState>(
             builder: (context, state) {
-              if (state.hasException) {
+              if (state is ErrorState) {
                 return ErrorScrollView(state.message!);
-              } else if (state.isLoading) {
+              } else if (state is LoadingState) {
                 return const Padding(
                   padding: EdgeInsets.all(16),
                   child: Center(child: CircularProgressIndicator()),
@@ -102,9 +103,9 @@ class _GroupsScreenState extends State<GroupsScreen>
           ),
           BlocBuilder<BoardsCubit, GroupsState>(
             builder: (context, state) {
-              if (state.hasException) {
+              if (state is ErrorState) {
                 return ErrorScrollView(state.message!);
-              } else if (state.isLoading) {
+              } else if (state is LoadingState) {
                 return const Padding(
                   padding: EdgeInsets.all(16),
                   child: Center(child: CircularProgressIndicator()),

--- a/lib/ui/screens/profile_screen.dart
+++ b/lib/ui/screens/profile_screen.dart
@@ -461,7 +461,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
       body: BlocBuilder<MemberCubit, MemberState>(
         bloc: _memberCubit,
         builder: (context, state) {
-          if (state.hasException) {
+          if (state is ErrorState) {
             return CustomScrollView(
               controller: _scrollController,
               slivers: [
@@ -471,7 +471,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 ),
               ],
             );
-          } else if (state.isLoading && widget.member == null) {
+          } else if (state is LoadingState && widget.member == null) {
             return CustomScrollView(
               controller: _scrollController,
               slivers: [
@@ -488,7 +488,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
               slivers: [
                 _makeAppBar((state.result ?? widget.member)!),
                 _makeFactsSliver((state.result ?? widget.member)!),
-                if (!state.isLoading) ...[
+                if (state is! LoadingState) ...[
                   if (state.result!.achievements.isNotEmpty)
                     _makeAchievementsSliver(state.result!),
                   if (state.result!.societies.isNotEmpty)

--- a/lib/ui/screens/registration_screen.dart
+++ b/lib/ui/screens/registration_screen.dart
@@ -45,7 +45,7 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
     return BlocBuilder<RegistrationFieldsCubit, RegistrationFieldsState>(
       bloc: _registrationFieldsCubit,
       builder: (context, state) {
-        if (state.hasException) {
+        if (state is ErrorState) {
           return Scaffold(
             appBar: ThaliaAppBar(
               title: const Text('REGISTRATION'),
@@ -53,7 +53,7 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
             ),
             body: ErrorCenter(state.message!),
           );
-        } else if (state.isLoading) {
+        } else if (state is LoadingState) {
           return Scaffold(
             appBar: ThaliaAppBar(
               title: const Text('REGISTRATION'),
@@ -61,7 +61,7 @@ class _RegistrationScreenState extends State<RegistrationScreen> {
             ),
             body: const Center(child: CircularProgressIndicator()),
           );
-        } else {}
+        }
         return Scaffold(
           appBar: ThaliaAppBar(
             title: const Text('REGISTRATION'),

--- a/lib/ui/widgets/sales_order_dialog.dart
+++ b/lib/ui/widgets/sales_order_dialog.dart
@@ -39,16 +39,7 @@ class _SalesOrderDialogState extends State<SalesOrderDialog> {
         late final Widget content;
         late final Widget payButton;
 
-        if (orderState.hasException) {
-          content = Text(
-            orderState.message!,
-            style: textTheme.bodyText2,
-          );
-          payButton = const SizedBox.shrink();
-        } else if (orderState.isLoading) {
-          content = const Center(child: CircularProgressIndicator());
-          payButton = const SizedBox.shrink();
-        } else {
+        if (orderState is ResultState) {
           final order = orderState.result!;
 
           if (order.numItems == 0) {
@@ -78,6 +69,15 @@ class _SalesOrderDialogState extends State<SalesOrderDialog> {
               amount: order.totalAmount,
             );
           }
+        } else if (orderState is ErrorState) {
+          content = Text(
+            orderState.message!,
+            style: textTheme.bodyText2,
+          );
+          payButton = const SizedBox.shrink();
+        } else {
+          content = const Center(child: CircularProgressIndicator());
+          payButton = const SizedBox.shrink();
         }
 
         return AlertDialog(
@@ -100,9 +100,10 @@ class _SalesOrderDialogState extends State<SalesOrderDialog> {
               label: const Text('CLOSE'),
             ),
             AnimatedSize(
-                curve: Curves.ease,
-                duration: const Duration(milliseconds: 200),
-                child: payButton),
+              curve: Curves.ease,
+              duration: const Duration(milliseconds: 200),
+              child: payButton,
+            ),
           ],
         );
       },

--- a/lib/ui/widgets/tpay_button.dart
+++ b/lib/ui/widgets/tpay_button.dart
@@ -113,14 +113,14 @@ class _TPayButtonState extends State<TPayButton> {
             label: buttonLabel,
           );
           // TODO: provide custom tooltip.
-        } else if (state.isLoading) {
+        } else if (state is LoadingState) {
           // PaymentUser loading.
           return ElevatedButton.icon(
             onPressed: null,
             icon: icon,
             label: buttonLabel,
           );
-        } else if (state.hasException) {
+        } else if (state is ErrorState) {
           // PaymentUser couldn't load.
           return ElevatedButton.icon(
             onPressed: null,

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -175,8 +175,8 @@ class _FakeSalesOrder_14 extends _i1.SmartFake implements _i3.SalesOrder {
         );
 }
 
-class _FakeApiRepository_15 extends _i1.SmartFake implements _i4.ApiRepository {
-  _FakeApiRepository_15(
+class _FakeGroup_15 extends _i1.SmartFake implements _i3.Group {
+  _FakeGroup_15(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -185,9 +185,19 @@ class _FakeApiRepository_15 extends _i1.SmartFake implements _i4.ApiRepository {
         );
 }
 
-class _FakeDetailState_16<E> extends _i1.SmartFake
-    implements _i2.DetailState<E> {
-  _FakeDetailState_16(
+class _FakeApiRepository_16 extends _i1.SmartFake implements _i4.ApiRepository {
+  _FakeApiRepository_16(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakeXDetailState_17<T> extends _i1.SmartFake
+    implements _i2.DetailState<T> {
+  _FakeXDetailState_17(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -573,6 +583,22 @@ class MockApiRepository extends _i1.Mock implements _i4.ApiRepository {
               ),
             )),
           ) as _i5.Future<_i3.ListResponse<_i3.AdminEventRegistration>>);
+  @override
+  _i5.Future<String> markPresentEventRegistration({
+    required int? eventPk,
+    required String? token,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #markPresentEventRegistration,
+          [],
+          {
+            #eventPk: eventPk,
+            #token: token,
+          },
+        ),
+        returnValue: _i5.Future<String>.value(''),
+      ) as _i5.Future<String>);
   @override
   _i5.Future<_i3.AdminEventRegistration> markPresentAdminEventRegistration({
     required int? eventPk,
@@ -1348,6 +1374,87 @@ class MockApiRepository extends _i1.Mock implements _i4.ApiRepository {
           ),
         )),
       ) as _i5.Future<_i3.SalesOrder>);
+  @override
+  _i5.Future<_i3.ListResponse<_i3.ListGroup>> getGroups({
+    int? limit,
+    int? offset,
+    _i3.MemberGroupType? type,
+    DateTime? start,
+    DateTime? end,
+    String? search,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getGroups,
+          [],
+          {
+            #limit: limit,
+            #offset: offset,
+            #type: type,
+            #start: start,
+            #end: end,
+            #search: search,
+          },
+        ),
+        returnValue: _i5.Future<_i3.ListResponse<_i3.ListGroup>>.value(
+            _FakeListResponse_2<_i3.ListGroup>(
+          this,
+          Invocation.method(
+            #getGroups,
+            [],
+            {
+              #limit: limit,
+              #offset: offset,
+              #type: type,
+              #start: start,
+              #end: end,
+              #search: search,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i3.ListResponse<_i3.ListGroup>>);
+  @override
+  _i5.Future<_i3.Group> getGroup({required int? pk}) => (super.noSuchMethod(
+        Invocation.method(
+          #getGroup,
+          [],
+          {#pk: pk},
+        ),
+        returnValue: _i5.Future<_i3.Group>.value(_FakeGroup_15(
+          this,
+          Invocation.method(
+            #getGroup,
+            [],
+            {#pk: pk},
+          ),
+        )),
+      ) as _i5.Future<_i3.Group>);
+  @override
+  _i5.Future<_i3.Group> getBoardGroup({
+    required int? since,
+    required int? until,
+  }) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #getBoardGroup,
+          [],
+          {
+            #since: since,
+            #until: until,
+          },
+        ),
+        returnValue: _i5.Future<_i3.Group>.value(_FakeGroup_15(
+          this,
+          Invocation.method(
+            #getBoardGroup,
+            [],
+            {
+              #since: since,
+              #until: until,
+            },
+          ),
+        )),
+      ) as _i5.Future<_i3.Group>);
 }
 
 /// A class which mocks [PaymentUserCubit].
@@ -1361,7 +1468,7 @@ class MockPaymentUserCubit extends _i1.Mock implements _i2.PaymentUserCubit {
   @override
   _i4.ApiRepository get api => (super.noSuchMethod(
         Invocation.getter(#api),
-        returnValue: _FakeApiRepository_15(
+        returnValue: _FakeApiRepository_16(
           this,
           Invocation.getter(#api),
         ),
@@ -1369,7 +1476,7 @@ class MockPaymentUserCubit extends _i1.Mock implements _i2.PaymentUserCubit {
   @override
   _i2.DetailState<_i3.PaymentUser> get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _FakeDetailState_16<_i3.PaymentUser>(
+        returnValue: _FakeXDetailState_17<_i3.PaymentUser>(
           this,
           Invocation.getter(#state),
         ),

--- a/test/widget/tpay_button_test.dart
+++ b/test/widget/tpay_button_test.dart
@@ -21,9 +21,9 @@ void main() {
         ..stream.listen((state) {
           when(paymentUserCubit.state).thenReturn(state);
         })
-        ..add(const PaymentUserState.loading())
-        ..add(const PaymentUserState.result(
-          result: PaymentUser('0.00', true, true),
+        ..add(const LoadingState())
+        ..add(const ResultState(
+          PaymentUser('0.00', true, true),
         ));
 
       when(paymentUserCubit.load()).thenAnswer((_) => Future.value(null));
@@ -72,9 +72,9 @@ void main() {
         ..stream.listen((state) {
           when(paymentUserCubit.state).thenReturn(state);
         })
-        ..add(const PaymentUserState.loading())
-        ..add(const PaymentUserState.result(
-          result: PaymentUser('0.00', true, true),
+        ..add(const LoadingState())
+        ..add(const ResultState(
+          PaymentUser('0.00', true, true),
         ));
 
       when(paymentUserCubit.load()).thenAnswer((_) => Future.value(null));
@@ -120,9 +120,9 @@ void main() {
         ..stream.listen((state) {
           when(paymentUserCubit.state).thenReturn(state);
         })
-        ..add(const PaymentUserState.loading())
-        ..add(const PaymentUserState.result(
-          result: PaymentUser('0.00', true, true),
+        ..add(const LoadingState())
+        ..add(const ResultState(
+          PaymentUser('0.00', true, true),
         ));
 
       when(paymentUserCubit.load()).thenAnswer((_) => Future.value(null));
@@ -161,9 +161,9 @@ void main() {
         ..stream.listen((state) {
           when(paymentUserCubit.state).thenReturn(state);
         })
-        ..add(const PaymentUserState.loading())
-        ..add(const PaymentUserState.result(
-          result: PaymentUser('0.00', false, false),
+        ..add(const LoadingState())
+        ..add(const ResultState(
+          PaymentUser('0.00', false, false),
         ));
 
       when(paymentUserCubit.load()).thenAnswer((_) => Future.value(null));
@@ -196,8 +196,8 @@ void main() {
         findsOneWidget,
       );
 
-      streamController.add(const PaymentUserState.result(
-        result: PaymentUser('0.00', true, false),
+      streamController.add(const ResultState(
+        PaymentUser('0.00', true, false),
       ));
       await tester.pumpAndSettle();
 
@@ -208,15 +208,13 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.textContaining('direct debit mandate'), findsOneWidget);
 
-      streamController.add(const PaymentUserState.loading());
+      streamController.add(const LoadingState());
       await tester.pumpAndSettle();
       await tester.tap(find.text('THALIA PAY: €13.37'));
       await tester.pumpAndSettle();
       expect(find.text('Confirm payment'), findsNothing);
 
-      streamController.add(const PaymentUserState.failure(
-        message: 'An unknown error occurred.',
-      ));
+      streamController.add(const ErrorState('An unknown error occurred.'));
       await tester.pumpAndSettle();
       await tester.tap(find.text('THALIA PAY: €13.37'));
       await tester.pumpAndSettle();


### PR DESCRIPTION
Closes #321.

### Summary
This moves the gallery back into a dialog. It also turned out that keeping the initial gallery index in the cubit's state is not necessary. 

Meanwhile, I figured out an (I think) elegant way to change `DetailState` into a class tree. Although I don't really like the `x is Y` syntax being used a lot, I think this reduces the required boilerplate (especially the number of null checks/assertions to enforce non-nullability of results depending on the status) and complexity when extending DetailState (i.e. another non-generic subtype can simply be added).
I think a change like this will help in starting to refactor towards more flexible and conventional classes as they're used e.g. for authentication.

### How to test
Steps to test the changes you made:
1. Open a gallery.
2. Close it using the android back button.
