### PR TITLE
Refactor ListState and paginated screens

### DIFF
--- a/lib/blocs/calendar_cubit.dart
+++ b/lib/blocs/calendar_cubit.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
 
+import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
-import 'package:reaxit/blocs.dart';
 import 'package:reaxit/config.dart' as config;
 import 'package:reaxit/models.dart';
 
@@ -103,7 +103,86 @@ class CalendarEvent {
       );
 }
 
-typedef CalendarState = ListState<CalendarEvent>;
+/// Generic class to be used as state for paginated lists.
+class CalendarState extends Equatable {
+  /// The results to be shown. These are outdated if `isLoading` is true.
+  final List<CalendarEvent> results;
+
+  /// A message describing why there are no results.
+  final String? message;
+
+  /// Different results are being loaded. The results are outdated.
+  final bool isLoading;
+
+  /// More of the same results are being loaded. The results are not outdated.
+  final bool isLoadingMore;
+
+  /// The last results have been loaded. There are no more pages left.
+  final bool isDone;
+
+  bool get hasException => message != null;
+
+  const CalendarState({
+    required this.results,
+    required this.message,
+    required this.isLoading,
+    required this.isLoadingMore,
+    required this.isDone,
+  });
+
+  CalendarState copyWith({
+    List<CalendarEvent>? results,
+    String? message,
+    bool? isLoading,
+    bool? isLoadingMore,
+    bool? isDone,
+  }) =>
+      CalendarState(
+        results: results ?? this.results,
+        message: message ?? this.message,
+        isLoading: isLoading ?? this.isLoading,
+        isLoadingMore: isLoadingMore ?? this.isLoadingMore,
+        isDone: isDone ?? this.isDone,
+      );
+
+  @override
+  List<Object?> get props => [
+        results,
+        message,
+        isLoading,
+        isLoadingMore,
+        isDone,
+      ];
+
+  @override
+  String toString() {
+    return 'ListState<$CalendarEvent>(isLoading: $isLoading, isLoadingMore: $isLoadingMore,'
+        ' isDone: $isDone, message: $message, ${results.length} ${CalendarEvent}s)';
+  }
+
+  const CalendarState.loading({required this.results})
+      : message = null,
+        isLoading = true,
+        isLoadingMore = false,
+        isDone = true;
+
+  const CalendarState.loadingMore({required this.results})
+      : message = null,
+        isLoading = false,
+        isLoadingMore = true,
+        isDone = true;
+
+  const CalendarState.success({required this.results, required this.isDone})
+      : message = null,
+        isLoading = false,
+        isLoadingMore = false;
+
+  const CalendarState.failure({required String this.message})
+      : results = const [],
+        isLoading = false,
+        isLoadingMore = false,
+        isDone = true;
+}
 
 class CalendarCubit extends Cubit<CalendarState> {
   static const int firstPageSize = 20;

--- a/lib/blocs/list_state.dart
+++ b/lib/blocs/list_state.dart
@@ -80,3 +80,68 @@ class ListState<T> extends Equatable {
         isLoadingMore = false,
         isDone = true;
 }
+
+/// Generic type for states with a paginated list of results.
+///
+/// There are a number of subtypes:
+/// * [ErrorListState] - indicates that there was an error.
+/// * [LoadingListState] - indicates that we are loading.
+/// * [ResultsListState] - indicates that there are results.
+///   * [DoneListState] - indicates that there are no more results.
+///   * [LoadingMoreListState] - indicates that we are loading more results.
+abstract class XListState<T> extends Equatable {
+  const XListState();
+
+  /// A convenience method to get the results if they are available.
+  ///
+  /// Returns `[]` if this state is not a (subtype of) [ResultsListState].
+  List<T> get results =>
+      this is ResultsListState ? (this as ResultsListState<T>).results : [];
+
+  /// A convenience method to get the error message if there is one.
+  ///
+  /// Returns `null` iff this state is not a (subtype of) [ErrorListState].
+  String? get message =>
+      this is ErrorListState ? (this as ErrorListState<T>).message : null;
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadingListState<T> extends XListState<T> {
+  const LoadingListState();
+}
+
+class ErrorListState<T> extends XListState<T> {
+  @override
+  final String message;
+
+  const ErrorListState(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}
+
+class ResultsListState<T> extends XListState<T> {
+  @override
+  final List<T> results;
+
+  const ResultsListState(this.results);
+
+  factory ResultsListState.withDone(List<T> results, bool isDone) =>
+      isDone ? DoneListState(results) : ResultsListState(results);
+
+  @override
+  List<Object?> get props => [results];
+}
+
+class LoadingMoreListState<T> extends ResultsListState<T> {
+  const LoadingMoreListState(super.results);
+
+  factory LoadingMoreListState.from(ResultsListState<T> state) =>
+      LoadingMoreListState(state.results);
+}
+
+class DoneListState<T> extends ResultsListState<T> {
+  const DoneListState(super.results);
+}

--- a/lib/blocs/list_state.dart
+++ b/lib/blocs/list_state.dart
@@ -1,86 +1,5 @@
 import 'package:equatable/equatable.dart';
 
-/// Generic class to be used as state for paginated lists.
-class ListState<T> extends Equatable {
-  /// The results to be shown. These are outdated if `isLoading` is true.
-  final List<T> results;
-
-  /// A message describing why there are no results.
-  final String? message;
-
-  /// Different results are being loaded. The results are outdated.
-  final bool isLoading;
-
-  /// More of the same results are being loaded. The results are not outdated.
-  final bool isLoadingMore;
-
-  /// The last results have been loaded. There are no more pages left.
-  final bool isDone;
-
-  bool get hasException => message != null;
-
-  const ListState({
-    required this.results,
-    required this.message,
-    required this.isLoading,
-    required this.isLoadingMore,
-    required this.isDone,
-  });
-
-  ListState<T> copyWith({
-    List<T>? results,
-    String? message,
-    bool? isLoading,
-    bool? isLoadingMore,
-    bool? isDone,
-  }) =>
-      ListState<T>(
-        results: results ?? this.results,
-        message: message ?? this.message,
-        isLoading: isLoading ?? this.isLoading,
-        isLoadingMore: isLoadingMore ?? this.isLoadingMore,
-        isDone: isDone ?? this.isDone,
-      );
-
-  @override
-  List<Object?> get props => [
-        results,
-        message,
-        isLoading,
-        isLoadingMore,
-        isDone,
-      ];
-
-  @override
-  String toString() {
-    return 'ListState<$T>(isLoading: $isLoading, isLoadingMore: $isLoadingMore,'
-        ' isDone: $isDone, message: $message, ${results.length} ${T}s)';
-  }
-
-  const ListState.loading({required this.results})
-      : message = null,
-        isLoading = true,
-        isLoadingMore = false,
-        isDone = true;
-
-  const ListState.loadingMore({required this.results})
-      : message = null,
-        isLoading = false,
-        isLoadingMore = true,
-        isDone = true;
-
-  const ListState.success({required this.results, required this.isDone})
-      : message = null,
-        isLoading = false,
-        isLoadingMore = false;
-
-  const ListState.failure({required String this.message})
-      : results = const [],
-        isLoading = false,
-        isLoadingMore = false,
-        isDone = true;
-}
-
 /// Generic type for states with a paginated list of results.
 ///
 /// There are a number of subtypes:
@@ -89,8 +8,8 @@ class ListState<T> extends Equatable {
 /// * [ResultsListState] - indicates that there are results.
 ///   * [DoneListState] - indicates that there are no more results.
 ///   * [LoadingMoreListState] - indicates that we are loading more results.
-abstract class XListState<T> extends Equatable {
-  const XListState();
+abstract class ListState<T> extends Equatable {
+  const ListState();
 
   /// A convenience method to get the results if they are available.
   ///
@@ -108,11 +27,11 @@ abstract class XListState<T> extends Equatable {
   List<Object?> get props => [];
 }
 
-class LoadingListState<T> extends XListState<T> {
+class LoadingListState<T> extends ListState<T> {
   const LoadingListState();
 }
 
-class ErrorListState<T> extends XListState<T> {
+class ErrorListState<T> extends ListState<T> {
   @override
   final String message;
 
@@ -122,7 +41,7 @@ class ErrorListState<T> extends XListState<T> {
   List<Object?> get props => [message];
 }
 
-class ResultsListState<T> extends XListState<T> {
+class ResultsListState<T> extends ListState<T> {
   @override
   final List<T> results;
 

--- a/lib/blocs/member_list_cubit.dart
+++ b/lib/blocs/member_list_cubit.dart
@@ -46,9 +46,7 @@ class MemberListCubit extends PaginatedCubit<ListMember> {
         if (query?.isEmpty ?? true) {
           emit(const ErrorListState('There are no members.'));
         } else {
-          emit(ErrorListState(
-            'There are no members found for "$query".',
-          ));
+          emit(ErrorListState('There are no members found for "$query".'));
         }
       } else {
         emit(ResultsListState.withDone(membersResponse.results, isDone));
@@ -64,6 +62,7 @@ class MemberListCubit extends PaginatedCubit<ListMember> {
     if (state is! ResultsListState ||
         state is LoadingMoreListState ||
         state is DoneListState) return;
+
     final oldState = state as ResultsListState<ListMember>;
 
     emit(LoadingMoreListState.from(oldState));

--- a/lib/blocs/member_list_cubit.dart
+++ b/lib/blocs/member_list_cubit.dart
@@ -1,18 +1,13 @@
 import 'dart:async';
 
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/config.dart' as config;
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
+import 'package:reaxit/ui/widgets.dart';
 
-typedef MemberListState = XListState<ListMember>;
-
-class MemberListCubit extends Cubit<MemberListState> {
-  static const int firstPageSize = 60;
-  static const int pageSize = 30;
-
+class MemberListCubit extends PaginatedCubit<ListMember> {
   final ApiRepository api;
 
   /// The last used search query. Can be set through `this.search(query)`.
@@ -27,8 +22,9 @@ class MemberListCubit extends Cubit<MemberListState> {
   /// The offset to be used for the next paginated request.
   int _nextOffset = 0;
 
-  MemberListCubit(this.api) : super(const LoadingListState());
+  MemberListCubit(this.api) : super(firstPageSize: 60, pageSize: 30);
 
+  @override
   Future<void> load() async {
     try {
       final query = _searchQuery;
@@ -62,6 +58,7 @@ class MemberListCubit extends Cubit<MemberListState> {
     }
   }
 
+  @override
   Future<void> more() async {
     // Ignore calls to `more()` if there is no data, or already more coming.
     if (state is! ResultsListState ||

--- a/lib/blocs/registrations_cubit.dart
+++ b/lib/blocs/registrations_cubit.dart
@@ -1,26 +1,21 @@
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
+import 'package:reaxit/ui/widgets.dart';
 
-typedef RegistrationsState = ListState<EventRegistration>;
-
-class RegistrationsCubit extends Cubit<RegistrationsState> {
+class RegistrationsCubit extends PaginatedCubit<EventRegistration> {
   final ApiRepository api;
   final int eventPk;
-
-  static const int firstPageSize = 60;
-  static const int pageSize = 30;
 
   /// The offset to be used for the next paginated request.
   int _nextOffset = 0;
 
   RegistrationsCubit(this.api, {required this.eventPk})
-      : super(const RegistrationsState.loading(results: []));
+      : super(firstPageSize: 60, pageSize: 30);
 
+  @override
   Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
     try {
       final listResponse = await api.getEventRegistrations(
           pk: eventPk, limit: firstPageSize, offset: 0);
@@ -30,27 +25,27 @@ class RegistrationsCubit extends Cubit<RegistrationsState> {
       _nextOffset = firstPageSize;
 
       if (listResponse.results.isNotEmpty) {
-        emit(RegistrationsState.success(
-            results: listResponse.results, isDone: isDone));
+        emit(ResultsListState.withDone(listResponse.results, isDone));
       } else {
-        emit(const RegistrationsState.failure(
-          message: 'There are no registrations yet.',
-        ));
+        emit(const ErrorListState('There are no registrations yet.'));
       }
     } on ApiException catch (exception) {
-      emit(RegistrationsState.failure(
-        message: exception.getMessage(notFound: 'The event does not exist.'),
+      emit(ErrorListState(
+        exception.getMessage(notFound: 'The event does not exist.'),
       ));
     }
   }
 
+  @override
   Future<void> more() async {
-    final oldState = state;
+    // Ignore calls to `more()` if there is no data, or already more coming.
+    if (state is! ResultsListState ||
+        state is LoadingMoreListState ||
+        state is DoneListState) return;
 
-    if (oldState.isDone || oldState.isLoading || oldState.isLoadingMore) return;
+    final oldState = state as ResultsListState<EventRegistration>;
 
-    emit(oldState.copyWith(isLoadingMore: true));
-
+    emit(LoadingMoreListState.from(oldState));
     try {
       var listResponse = await api.getEventRegistrations(
         pk: eventPk,
@@ -63,10 +58,10 @@ class RegistrationsCubit extends Cubit<RegistrationsState> {
 
       _nextOffset += pageSize;
 
-      emit(RegistrationsState.success(results: registrations, isDone: isDone));
+      emit(ResultsListState.withDone(registrations, isDone));
     } on ApiException catch (exception) {
-      emit(RegistrationsState.failure(
-        message: exception.getMessage(notFound: 'The event does not exist.'),
+      emit(ErrorListState(
+        exception.getMessage(notFound: 'The event does not exist.'),
       ));
     }
   }

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -548,11 +548,10 @@ class _EventScreenState extends State<EventScreen> {
                             _makeRegistrations(listState),
                             if (listState is LoadingMoreListState)
                               const SliverPadding(
-                                padding: EdgeInsets.all(8),
-                                sliver: SliverList(
-                                  delegate: SliverChildListDelegate.fixed([
-                                    Center(child: CircularProgressIndicator()),
-                                  ]),
+                                padding: EdgeInsets.only(top: 16),
+                                sliver: SliverToBoxAdapter(
+                                  child: Center(
+                                      child: CircularProgressIndicator()),
                                 ),
                               ),
                           ],

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -429,7 +429,7 @@ class _EventScreenState extends State<EventScreen> {
     );
   }
 
-  SliverPadding _makeRegistrations(XListState<EventRegistration> state) {
+  SliverPadding _makeRegistrations(ListState<EventRegistration> state) {
     if (state is ErrorListState) {
       return SliverPadding(
         padding: const EdgeInsets.only(left: 16, right: 16, top: 0, bottom: 16),
@@ -520,7 +520,7 @@ class _EventScreenState extends State<EventScreen> {
                   await _eventCubit.load();
                 },
                 child: BlocBuilder<RegistrationsCubit,
-                    XListState<EventRegistration>>(
+                    ListState<EventRegistration>>(
                   bloc: _registrationsCubit,
                   builder: (context, listState) {
                     return Scrollbar(

--- a/lib/ui/screens/members_screen.dart
+++ b/lib/ui/screens/members_screen.dart
@@ -42,32 +42,6 @@ class MembersScreen extends StatelessWidget {
   }
 }
 
-class _MembersGrid extends StatelessWidget {
-  const _MembersGrid(this.results);
-
-  final List<ListMember> results;
-
-  @override
-  Widget build(BuildContext context) {
-    return SliverPadding(
-      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
-      sliver: SliverGrid(
-        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-          crossAxisCount: 3,
-          mainAxisSpacing: 8,
-          crossAxisSpacing: 8,
-        ),
-        delegate: SliverChildBuilderDelegate(
-          (context, index) => MemberTile(
-            member: results[index],
-          ),
-          childCount: results.length,
-        ),
-      ),
-    );
-  }
-}
-
 class MembersSearchDelegate extends SearchDelegate {
   final MemberListCubit _cubit;
 
@@ -126,6 +100,32 @@ class MembersSearchDelegate extends SearchDelegate {
       value: _cubit..search(query),
       child: PaginatedScrollView<ListMember, MemberListCubit>(
         resultsBuilder: (_, results) => [_MembersGrid(results)],
+      ),
+    );
+  }
+}
+
+class _MembersGrid extends StatelessWidget {
+  const _MembersGrid(this.results);
+
+  final List<ListMember> results;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverPadding(
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+      sliver: SliverGrid(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 3,
+          mainAxisSpacing: 8,
+          crossAxisSpacing: 8,
+        ),
+        delegate: SliverChildBuilderDelegate(
+          (context, index) => MemberTile(
+            member: results[index],
+          ),
+          childCount: results.length,
+        ),
       ),
     );
   }

--- a/lib/ui/screens/members_screen.dart
+++ b/lib/ui/screens/members_screen.dart
@@ -34,16 +34,8 @@ class MembersScreen extends StatelessWidget {
       drawer: MenuDrawer(),
       body: RefreshIndicator(
         onRefresh: () => BlocProvider.of<MemberListCubit>(context).load(),
-        child: BlocBuilder<MemberListCubit, MemberListState>(
-          builder: (context, listState) {
-            return PaginatedScrollView<ListMember>(
-              state: listState,
-              onLoadMore: (context) {
-                BlocProvider.of<MemberListCubit>(context).more();
-              },
-              resultsBuilder: (_, results) => [_MembersGrid(results)],
-            );
-          },
+        child: PaginatedScrollView<ListMember, MemberListCubit>(
+          resultsBuilder: (_, results) => [_MembersGrid(results)],
         ),
       ),
     );
@@ -120,33 +112,21 @@ class MembersSearchDelegate extends SearchDelegate {
 
   @override
   Widget buildResults(BuildContext context) {
-    return BlocBuilder<MemberListCubit, MemberListState>(
-      bloc: _cubit..search(query),
-      builder: (context, listState) {
-        return PaginatedScrollView<ListMember>(
-          state: listState,
-          onLoadMore: (context) {
-            _cubit.more();
-          },
-          resultsBuilder: (_, results) => [_MembersGrid(results)],
-        );
-      },
+    return BlocProvider.value(
+      value: _cubit..search(query),
+      child: PaginatedScrollView<ListMember, MemberListCubit>(
+        resultsBuilder: (_, results) => [_MembersGrid(results)],
+      ),
     );
   }
 
   @override
   Widget buildSuggestions(BuildContext context) {
-    return BlocBuilder<MemberListCubit, MemberListState>(
-      bloc: _cubit..search(query),
-      builder: (context, listState) {
-        return PaginatedScrollView<ListMember>(
-          state: listState,
-          onLoadMore: (context) {
-            _cubit.more();
-          },
-          resultsBuilder: (_, results) => [_MembersGrid(results)],
-        );
-      },
+    return BlocProvider.value(
+      value: _cubit..search(query),
+      child: PaginatedScrollView<ListMember, MemberListCubit>(
+        resultsBuilder: (_, results) => [_MembersGrid(results)],
+      ),
     );
   }
 }

--- a/lib/ui/screens/members_screen.dart
+++ b/lib/ui/screens/members_screen.dart
@@ -3,40 +3,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/blocs.dart';
+import 'package:reaxit/models/member.dart';
 import 'package:reaxit/ui/widgets.dart';
 
-class MembersScreen extends StatefulWidget {
-  @override
-  State<MembersScreen> createState() => _MembersScreenState();
-}
-
-class _MembersScreenState extends State<MembersScreen> {
-  late ScrollController _controller;
-  late MemberListCubit _cubit;
-
-  @override
-  void initState() {
-    _cubit = BlocProvider.of<MemberListCubit>(context);
-    _controller = ScrollController()..addListener(_scrollListener);
-    super.initState();
-  }
-
-  void _scrollListener() {
-    if (_controller.position.pixels >=
-        _controller.position.maxScrollExtent - 300) {
-      // Only request loading more if that's not already happening.
-      if (!_cubit.state.isLoadingMore) {
-        _cubit.more();
-      }
-    }
-  }
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
+class MembersScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -63,21 +33,43 @@ class _MembersScreenState extends State<MembersScreen> {
       ),
       drawer: MenuDrawer(),
       body: RefreshIndicator(
-        onRefresh: () async {
-          await _cubit.load();
-        },
+        onRefresh: () => BlocProvider.of<MemberListCubit>(context).load(),
         child: BlocBuilder<MemberListCubit, MemberListState>(
           builder: (context, listState) {
-            if (listState.hasException) {
-              return ErrorScrollView(listState.message!);
-            } else {
-              return MemberListScrollView(
-                key: const PageStorageKey('members'),
-                controller: _controller,
-                listState: listState,
-              );
-            }
+            return PaginatedScrollView<ListMember>(
+              state: listState,
+              onLoadMore: (context) {
+                BlocProvider.of<MemberListCubit>(context).more();
+              },
+              resultsBuilder: (_, results) => [_MembersGrid(results)],
+            );
           },
+        ),
+      ),
+    );
+  }
+}
+
+class _MembersGrid extends StatelessWidget {
+  const _MembersGrid(this.results);
+
+  final List<ListMember> results;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverPadding(
+      padding: const EdgeInsets.fromLTRB(8, 8, 8, 0),
+      sliver: SliverGrid(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 3,
+          mainAxisSpacing: 8,
+          crossAxisSpacing: 8,
+        ),
+        delegate: SliverChildBuilderDelegate(
+          (context, index) => MemberTile(
+            member: results[index],
+          ),
+          childCount: results.length,
         ),
       ),
     );
@@ -86,21 +78,8 @@ class _MembersScreenState extends State<MembersScreen> {
 
 class MembersSearchDelegate extends SearchDelegate {
   final MemberListCubit _cubit;
-  late final ScrollController _controller;
 
-  MembersSearchDelegate(this._cubit) {
-    _controller = ScrollController()..addListener(_scrollListener);
-  }
-
-  void _scrollListener() {
-    if (_controller.position.pixels >=
-        _controller.position.maxScrollExtent - 300) {
-      // Only request loading more if that's not already happening.
-      if (!_cubit.state.isLoadingMore) {
-        _cubit.more();
-      }
-    }
-  }
+  MembersSearchDelegate(this._cubit);
 
   @override
   ThemeData appBarTheme(BuildContext context) {
@@ -144,15 +123,13 @@ class MembersSearchDelegate extends SearchDelegate {
     return BlocBuilder<MemberListCubit, MemberListState>(
       bloc: _cubit..search(query),
       builder: (context, listState) {
-        if (listState.hasException) {
-          return ErrorScrollView(listState.message!);
-        } else {
-          return MemberListScrollView(
-            key: const PageStorageKey('members-search'),
-            controller: _controller,
-            listState: listState,
-          );
-        }
+        return PaginatedScrollView<ListMember>(
+          state: listState,
+          onLoadMore: (context) {
+            _cubit.more();
+          },
+          resultsBuilder: (_, results) => [_MembersGrid(results)],
+        );
       },
     );
   }
@@ -162,72 +139,14 @@ class MembersSearchDelegate extends SearchDelegate {
     return BlocBuilder<MemberListCubit, MemberListState>(
       bloc: _cubit..search(query),
       builder: (context, listState) {
-        if (listState.hasException) {
-          return ErrorScrollView(listState.message!);
-        } else {
-          return MemberListScrollView(
-            key: const PageStorageKey('members-search'),
-            controller: _controller,
-            listState: listState,
-          );
-        }
+        return PaginatedScrollView<ListMember>(
+          state: listState,
+          onLoadMore: (context) {
+            _cubit.more();
+          },
+          resultsBuilder: (_, results) => [_MembersGrid(results)],
+        );
       },
     );
-  }
-}
-
-/// A ScrollView that shows a grid of [MemberTile]s.
-///
-/// This does not take care of communicating with a Cubit. The [controller]
-/// should do that. The [listState] also must not have an exception.
-class MemberListScrollView extends StatelessWidget {
-  final ScrollController controller;
-  final MemberListState listState;
-
-  const MemberListScrollView({
-    Key? key,
-    required this.controller,
-    required this.listState,
-  }) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    return Scrollbar(
-        controller: controller,
-        child: CustomScrollView(
-          controller: controller,
-          physics: const RangeMaintainingScrollPhysics(
-            parent: AlwaysScrollableScrollPhysics(),
-          ),
-          slivers: [
-            SliverPadding(
-              padding: const EdgeInsets.all(8),
-              sliver: SliverGrid(
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                  crossAxisCount: 3,
-                  mainAxisSpacing: 8,
-                  crossAxisSpacing: 8,
-                ),
-                delegate: SliverChildBuilderDelegate(
-                  (context, index) => MemberTile(
-                    member: listState.results[index],
-                  ),
-                  childCount: listState.results.length,
-                ),
-              ),
-            ),
-            if (listState.isLoadingMore)
-              const SliverPadding(
-                padding: EdgeInsets.all(8),
-                sliver: SliverList(
-                  delegate: SliverChildListDelegate.fixed([
-                    Center(
-                      child: CircularProgressIndicator(),
-                    )
-                  ]),
-                ),
-              ),
-          ],
-        ));
   }
 }

--- a/lib/ui/widgets.dart
+++ b/lib/ui/widgets.dart
@@ -7,6 +7,7 @@ export 'widgets/event_detail_card.dart';
 export 'widgets/mark_present_dialog.dart';
 export 'widgets/member_tile.dart';
 export 'widgets/menu_drawer.dart';
+export 'widgets/paginated_scroll_view.dart';
 export 'widgets/push_notification_dialog.dart';
 export 'widgets/push_notification_overlay.dart';
 export 'widgets/sales_order_dialog.dart';

--- a/lib/ui/widgets/paginated_scroll_view.dart
+++ b/lib/ui/widgets/paginated_scroll_view.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/blocs/list_state.dart';
 
-abstract class PaginatedCubit<E> extends Cubit<XListState<E>> {
+abstract class PaginatedCubit<E> extends Cubit<ListState<E>> {
   final int firstPageSize;
   final int pageSize;
 
@@ -76,7 +76,7 @@ class _PaginatedScrollViewState<E, B extends PaginatedCubit<E>>
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<B, XListState<E>>(
+    return BlocBuilder<B, ListState<E>>(
       builder: (context, state) {
         late final List<Widget> slivers;
         if (state is ErrorListState) {

--- a/lib/ui/widgets/paginated_scroll_view.dart
+++ b/lib/ui/widgets/paginated_scroll_view.dart
@@ -1,24 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/blocs/list_state.dart';
 
+abstract class PaginatedCubit<E> extends Cubit<XListState<E>> {
+  final int firstPageSize;
+  final int pageSize;
+
+  PaginatedCubit({
+    required this.firstPageSize,
+    required this.pageSize,
+  }) : super(const LoadingListState());
+
+  /// Load the first page of results.
+  Future<void> load();
+
+  /// Load another page of results.
+  Future<void> more();
+}
+
 /// A widget that displays and triggers loading of a paginated list.
-class PaginatedScrollView<T> extends StatefulWidget {
+class PaginatedScrollView<E, B extends PaginatedCubit<E>>
+    extends StatefulWidget {
   const PaginatedScrollView({
     super.key,
-    required this.state,
-    required this.onLoadMore,
     required this.resultsBuilder,
     this.loadingBuilder,
   });
-
-  final XListState<T> state;
 
   /// A builder that creates a list of slivers from the results.
   ///
   /// For example, this could return a list with a single [SliverGrid].
   final List<Widget> Function(
     BuildContext context,
-    List<T> results,
+    List<E> results,
   ) resultsBuilder;
 
   /// An optional builder for a list of slivers to be shown when loading.
@@ -26,18 +40,13 @@ class PaginatedScrollView<T> extends StatefulWidget {
   /// If this is not provided, nothing will be shown.
   final List<Widget> Function(BuildContext context)? loadingBuilder;
 
-  /// A callback that is called when more results should be loaded.
-  ///
-  /// This should trigger the loading of another page of results.
-  /// This is only called when the current state is [ResultsListState],
-  /// not from [LoadingMoreListState] or [DoneListState].
-  final void Function(BuildContext context) onLoadMore;
-
   @override
-  State<PaginatedScrollView<T>> createState() => _PaginatedScrollViewState<T>();
+  State<PaginatedScrollView<E, B>> createState() =>
+      _PaginatedScrollViewState<E, B>();
 }
 
-class _PaginatedScrollViewState<T> extends State<PaginatedScrollView<T>> {
+class _PaginatedScrollViewState<E, B extends PaginatedCubit<E>>
+    extends State<PaginatedScrollView<E, B>> {
   late ScrollController controller;
 
   @override
@@ -55,75 +64,78 @@ class _PaginatedScrollViewState<T> extends State<PaginatedScrollView<T>> {
   void _scrollListener() {
     final position = controller.position;
     if (position.pixels >= position.maxScrollExtent - 300) {
-      if (widget.state is ResultsListState &&
-          widget.state is! DoneListState &&
-          widget.state is! LoadingMoreListState) {
-        widget.onLoadMore(context);
+      final cubit = BlocProvider.of<B>(context);
+      final state = cubit.state;
+      if (state is ResultsListState &&
+          state is! DoneListState &&
+          state is! LoadingMoreListState) {
+        cubit.more();
       }
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    late final List<Widget> slivers;
-    if (widget.state is ErrorListState) {
-      slivers = [
-        SliverSafeArea(
-          minimum: const EdgeInsets.all(16),
-          sliver: SliverToBoxAdapter(
-            child: Column(
-              children: [
-                Container(
-                  height: 100,
-                  margin: const EdgeInsets.all(12),
-                  child: Image.asset(
-                    'assets/img/sad-cloud.png',
-                    fit: BoxFit.fitHeight,
-                  ),
+    return BlocBuilder<B, XListState<E>>(
+      builder: (context, state) {
+        late final List<Widget> slivers;
+        if (state is ErrorListState) {
+          slivers = [
+            SliverSafeArea(
+              minimum: const EdgeInsets.all(16),
+              sliver: SliverToBoxAdapter(
+                child: Column(
+                  children: [
+                    Container(
+                      height: 100,
+                      margin: const EdgeInsets.all(12),
+                      child: Image.asset(
+                        'assets/img/sad-cloud.png',
+                        fit: BoxFit.fitHeight,
+                      ),
+                    ),
+                    Text(state.message!, textAlign: TextAlign.center),
+                  ],
                 ),
-                Text(widget.state.message!, textAlign: TextAlign.center),
-              ],
+              ),
             ),
-          ),
-        ),
-      ];
-    } else if (widget.state is LoadingListState) {
-      if (widget.loadingBuilder != null) {
-        slivers = widget.loadingBuilder!(context);
-      } else {
-        slivers = [];
-      }
-    } else {
-      final resultsSlivers = widget.resultsBuilder(
-        context,
-        widget.state.results,
-      );
+          ];
+        } else if (state is LoadingListState) {
+          if (widget.loadingBuilder != null) {
+            slivers = widget.loadingBuilder!(context);
+          } else {
+            slivers = [];
+          }
+        } else {
+          final resultSlivers = widget.resultsBuilder(context, state.results);
 
-      slivers = [
-        ...resultsSlivers,
-        if (widget.state is LoadingMoreListState)
-          const SliverPadding(
-            padding: EdgeInsets.only(top: 16),
-            sliver: SliverToBoxAdapter(
-              child: Center(child: CircularProgressIndicator()),
+          slivers = [
+            ...resultSlivers,
+            if (state is LoadingMoreListState)
+              const SliverPadding(
+                padding: EdgeInsets.only(top: 16),
+                sliver: SliverToBoxAdapter(
+                  child: Center(child: CircularProgressIndicator()),
+                ),
+              ),
+            const SliverSafeArea(
+              minimum: EdgeInsets.only(bottom: 8),
+              sliver: SliverPadding(padding: EdgeInsets.zero),
             ),
-          ),
-        const SliverSafeArea(
-          minimum: EdgeInsets.only(bottom: 8),
-          sliver: SliverPadding(padding: EdgeInsets.zero),
-        ),
-      ];
-    }
+          ];
+        }
 
-    return Scrollbar(
-      controller: controller,
-      child: CustomScrollView(
-        controller: controller,
-        physics: const RangeMaintainingScrollPhysics(
-          parent: AlwaysScrollableScrollPhysics(),
-        ),
-        slivers: slivers,
-      ),
+        return Scrollbar(
+          controller: controller,
+          child: CustomScrollView(
+            controller: controller,
+            physics: const RangeMaintainingScrollPhysics(
+              parent: AlwaysScrollableScrollPhysics(),
+            ),
+            slivers: slivers,
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/ui/widgets/paginated_scroll_view.dart
+++ b/lib/ui/widgets/paginated_scroll_view.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:reaxit/blocs/list_state.dart';
+
+/// A widget that displays and triggers loading of a paginated list.
+class PaginatedScrollView<T> extends StatefulWidget {
+  const PaginatedScrollView({
+    super.key,
+    required this.state,
+    required this.onLoadMore,
+    required this.resultsBuilder,
+    this.loadingBuilder,
+  });
+
+  final XListState<T> state;
+
+  /// A builder that creates a list of slivers from the results.
+  ///
+  /// For example, this could return a list with a single [SliverGrid].
+  final List<Widget> Function(
+    BuildContext context,
+    List<T> results,
+  ) resultsBuilder;
+
+  /// An optional builder for a list of slivers to be shown when loading.
+  ///
+  /// If this is not provided, nothing will be shown.
+  final List<Widget> Function(BuildContext context)? loadingBuilder;
+
+  /// A callback that is called when more results should be loaded.
+  ///
+  /// This should trigger the loading of another page of results.
+  /// This is only called when the current state is [ResultsListState],
+  /// not from [LoadingMoreListState] or [DoneListState].
+  final void Function(BuildContext context) onLoadMore;
+
+  @override
+  State<PaginatedScrollView<T>> createState() => _PaginatedScrollViewState<T>();
+}
+
+class _PaginatedScrollViewState<T> extends State<PaginatedScrollView<T>> {
+  late ScrollController controller;
+
+  @override
+  void initState() {
+    controller = ScrollController()..addListener(_scrollListener);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  void _scrollListener() {
+    final position = controller.position;
+    if (position.pixels >= position.maxScrollExtent - 300) {
+      if (widget.state is ResultsListState &&
+          widget.state is! DoneListState &&
+          widget.state is! LoadingMoreListState) {
+        widget.onLoadMore(context);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    late final List<Widget> slivers;
+    if (widget.state is ErrorListState) {
+      slivers = [
+        SliverSafeArea(
+          minimum: const EdgeInsets.all(16),
+          sliver: SliverToBoxAdapter(
+            child: Column(
+              children: [
+                Container(
+                  height: 100,
+                  margin: const EdgeInsets.all(12),
+                  child: Image.asset(
+                    'assets/img/sad-cloud.png',
+                    fit: BoxFit.fitHeight,
+                  ),
+                ),
+                Text(widget.state.message!, textAlign: TextAlign.center),
+              ],
+            ),
+          ),
+        ),
+      ];
+    } else if (widget.state is LoadingListState) {
+      if (widget.loadingBuilder != null) {
+        slivers = widget.loadingBuilder!(context);
+      } else {
+        slivers = [];
+      }
+    } else {
+      final resultsSlivers = widget.resultsBuilder(
+        context,
+        widget.state.results,
+      );
+
+      slivers = [
+        ...resultsSlivers,
+        if (widget.state is LoadingMoreListState)
+          const SliverPadding(
+            padding: EdgeInsets.only(top: 16),
+            sliver: SliverToBoxAdapter(
+              child: Center(child: CircularProgressIndicator()),
+            ),
+          ),
+        const SliverSafeArea(
+          minimum: EdgeInsets.only(bottom: 8),
+          sliver: SliverPadding(padding: EdgeInsets.zero),
+        ),
+      ];
+    }
+
+    return Scrollbar(
+      controller: controller,
+      child: CustomScrollView(
+        controller: controller,
+        physics: const RangeMaintainingScrollPhysics(
+          parent: AlwaysScrollableScrollPhysics(),
+        ),
+        slivers: slivers,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -480,7 +480,7 @@ packages:
       name: go_router
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "6.0.1"
   google_fonts:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -110,7 +110,7 @@ dependencies:
   flutter_cache_manager: ^3.3.0
 
   # Navigation.
-  go_router: ^5.1.10
+  go_router: ^6.0.1
 
   # Displaying QR codes.
   qr_flutter: ^4.0.0


### PR DESCRIPTION
Part of #99.

### Summary
This replaces the old ListState in a way similar to what I did in #325. Introduces `PaginatedScrollView` and a `PaginatedCubit` abstract class to handle most logic for paginated lists/grids.

### How to test
Steps to test the changes you made:
1. Try out all of the paginated list screens (including search).
2. Check out their botton padding, which should now be consistent and include a `SafeArea`.
