### PR TITLE
Fix messahe for queue cancelation past the deadline

### DIFF
--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -221,7 +221,7 @@ class _EventScreenState extends State<EventScreen> {
         registrationButton = _makeCreateRegistrationButton(event);
       }
     } else if (event.canCancelRegistration) {
-      if (event.cancelDeadlinePassed()) {
+      if (event.cancelDeadlinePassed() && event.registration!.isInvited) {
         // Cancel too late message, cancel button with fine warning.
         textSpans.add(TextSpan(
           text: event.cancelTooLateMessage,
@@ -587,7 +587,6 @@ class _EventScreenState extends State<EventScreen> {
               ) ??
               false;
         }
-
         if (confirmed) {
           try {
             final registration = await _eventCubit.register();

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -587,6 +587,7 @@ class _EventScreenState extends State<EventScreen> {
               ) ??
               false;
         }
+
         if (confirmed) {
           try {
             final registration = await _eventCubit.register();


### PR DESCRIPTION
Closes #343 .

### Summary
This fixes the message when canceling after the deadline

### How to test
Steps to test the changes you made:
1. Go to an event that is past the deadline but you are in the queue
2. See message
