### PR TITLE
Make the registered message more clear for optional regs

### DIFF
--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -443,7 +443,7 @@ class _EventScreenState extends State<EventScreen> {
       textSpans.add(const TextSpan(
           text:
               'You are registered. This is only an indication that you intend '
-              'to be present. Access to the event is not handled by thalia.'));
+              'to be present. Access to the event is not handled by Thalia.'));
     } else if (event.canCreateRegistration) {
       textSpans.add(const TextSpan(
         text: 'Even though registration is not required for this event, you '

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -440,7 +440,10 @@ class _EventScreenState extends State<EventScreen> {
     }
 
     if (event.isInvited) {
-      textSpans.add(const TextSpan(text: 'You are registered. '));
+      textSpans.add(const TextSpan(
+          text:
+              'You are registered. This is only an indication that you intend '
+              'to be present. Access to the event is not handled by thalia.'));
     } else if (event.canCreateRegistration) {
       textSpans.add(const TextSpan(
         text: 'Even though registration is not required for this event, you '


### PR DESCRIPTION
Closes #344 

### Summary
To some new thalians it was not clear that events like beetfeest still require tickets, because the message seemed to indicate registration.

### How to test
Steps to test the changes you made:
1. Go to an optional registration event
2. Click on register
