### PR TITLE
Made commitee and society groups display in alphabetical order

### DIFF
--- a/lib/blocs/groups_cubit.dart
+++ b/lib/blocs/groups_cubit.dart
@@ -22,9 +22,7 @@ class GroupsCubit extends Cubit<GroupsState> {
       if (listResponse.results.isNotEmpty) {
         List<ListGroup> results = listResponse.results;
 
-        // Reverse because for some reason commitees and societies
-        // are sorted in reverse alphabetical order.
-        if (results.first.type != MemberGroupType.board) {
+        if (results.first.type == MemberGroupType.board) {
           results = results.reversed.toList();
         }
 

--- a/lib/blocs/groups_cubit.dart
+++ b/lib/blocs/groups_cubit.dart
@@ -20,7 +20,15 @@ class GroupsCubit extends Cubit<GroupsState> {
     try {
       final listResponse = await api.getGroups(limit: 1000, type: groupType);
       if (listResponse.results.isNotEmpty) {
-        emit(ResultState(listResponse.results));
+        List<ListGroup> results = listResponse.results;
+
+        // Reverse because for some reason commitees and societies
+        // are sorted in reverse alphabetical order.
+        if (results.first.type != MemberGroupType.board) {
+          results = results.reversed.toList();
+        }
+
+        emit(ResultState(results));
       } else {
         emit(const ErrorState('There are no groups.'));
       }

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -148,11 +148,7 @@ class GroupListScrollView extends StatelessWidget {
       : activeBoard = groups.firstWhereOrNull(
           (element) => element.isActiveBoard(),
         ),
-        groups = groups
-            .where((element) => !element.isActiveBoard())
-            .toList()
-            .reversed
-            .toList(),
+        groups = groups.where((element) => !element.isActiveBoard()).toList(),
         super(key: key);
 
   @override


### PR DESCRIPTION
Closes #350 .

### Summary
Made committee and society groups display in alphabetical order

### How to test
Steps to test the changes you made:
1. Go to 'GROUPS'.
2. Click on committees or societies.
3. See that it is in alphabetical order.
4. Boards are still from newest to oldest.
