### PR TITLE
Make default error messages better

### DIFF
--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -95,6 +95,8 @@ class ConcrexitApiRepository implements ApiRepository {
           throw ApiException.notAllowed;
         case 404:
           throw ApiException.notFound;
+        case 500:
+          throw ApiException.internalServerError;
         default:
           throw ApiException.unknownError;
       }

--- a/lib/api/exceptions.dart
+++ b/lib/api/exceptions.dart
@@ -41,6 +41,7 @@ class ApiException implements Exception {
     String? notAllowed,
     String? notLoggedIn,
     String? noInternet,
+    String? serverError,
   }) {
     switch (runtimeType) {
       case _UnknownException:
@@ -53,6 +54,8 @@ class ApiException implements Exception {
         return notLoggedIn ?? message;
       case _NoInternetException:
         return notAllowed ?? message;
+      case _InternalServerException:
+        return serverError ?? message;
       default:
         return message;
     }

--- a/lib/api/exceptions.dart
+++ b/lib/api/exceptions.dart
@@ -12,6 +12,7 @@ class ApiException implements Exception {
   static const notAllowed = _NotAllowedException();
   static const notLoggedIn = _NotLoggedInException();
   static const noInternet = _NoInternetException();
+  static const internalServerError = _InternalServerException();
 
   const ApiException._(this._message);
   factory ApiException.message(String message) => _MessageException(message);
@@ -76,6 +77,10 @@ class _NotLoggedInException extends ApiException {
 
 class _NoInternetException extends ApiException {
   const _NoInternetException() : super._('Could not connect to the server.');
+}
+
+class _InternalServerException extends ApiException {
+  const _InternalServerException() : super._('Server error.');
 }
 
 class _MessageException extends ApiException {

--- a/lib/api/exceptions.dart
+++ b/lib/api/exceptions.dart
@@ -13,11 +13,11 @@ class ApiException implements Exception {
   static const notLoggedIn = _NotLoggedInException();
   static const noInternet = _NoInternetException();
 
-  const ApiException._([this._message]);
+  const ApiException._(this._message);
   factory ApiException.message(String message) => _MessageException(message);
 
-  final String? _message;
-  String get message => _message ?? 'An unknown error occurred.';
+  final String _message;
+  String get message => _message;
 
   bool get isMessage => this is _MessageException;
 
@@ -35,27 +35,39 @@ class ApiException implements Exception {
   /// Without specifying `notFound`, the default message would also be used for
   /// [ApiException.notFound].
   String getMessage({
+    String? unknown,
     String? notFound,
     String? notAllowed,
-    String? unknown,
+    String? notLoggedIn,
+    String? noInternet,
   }) {
-    if (this is _NotFoundException) return notFound ?? message;
-    if (this is _NotAllowedException) return notAllowed ?? message;
-    if (this is _UnknownException) return unknown ?? message;
-    return message;
+    switch (runtimeType) {
+      case _UnknownException:
+        return unknown ?? message;
+      case _NotFoundException:
+        return notFound ?? message;
+      case _NotAllowedException:
+        return notAllowed ?? message;
+      case _NotLoggedInException:
+        return notLoggedIn ?? message;
+      case _NoInternetException:
+        return notAllowed ?? message;
+      default:
+        return message;
+    }
   }
 }
 
 class _UnknownException extends ApiException {
-  const _UnknownException() : super._();
+  const _UnknownException() : super._('An unknown error occurred.');
 }
 
 class _NotFoundException extends ApiException {
-  const _NotFoundException() : super._();
+  const _NotFoundException() : super._('Could not find this.');
 }
 
 class _NotAllowedException extends ApiException {
-  const _NotAllowedException() : super._();
+  const _NotAllowedException() : super._('You are not allowed to view this.');
 }
 
 class _NotLoggedInException extends ApiException {

--- a/lib/blocs/member_list_cubit.dart
+++ b/lib/blocs/member_list_cubit.dart
@@ -97,7 +97,7 @@ class MemberListCubit extends Cubit<MemberListState> {
         isDone: isDone,
       ));
     } on ApiException catch (exception) {
-      emit(MemberListState.failure(message: exception.getMessage()));
+      emit(MemberListState.failure(message: exception.message));
     }
   }
 

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -78,7 +78,7 @@ const List<String> oauthScopes = [
 
 const Duration searchDebounceTime = Duration(milliseconds: 200);
 
-const String versionNumber = 'v3.3.2';
+const String versionNumber = 'v3.4.0';
 
 final Uri feedbackUri = Uri.parse(
   'https://github.com/svthalia/Reaxit/issues',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ publish_to: 'none'
 # In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
-version: 3.3.2+1
+version: 3.4.0+1
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
Closes #352 .

### Summary
This makes the default messages a lot better, especially when not using custom error messages

### How to test
Not really possible, this is mostly for internal debugging and feedback to users for edge cases
