### PR TITLE
Fix pay button displaying when tpay is not allowed

### DIFF
--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -320,7 +320,8 @@ class _EventScreenState extends State<EventScreen> {
     late Widget paymentButton;
     if (event.isInvited &&
         event.paymentIsRequired &&
-        !event.registration!.isPaid) {
+        !event.registration!.isPaid &&
+        event.registration!.tpayAllowed) {
       paymentButton = TPayButton(
         onPay: () => _eventCubit.thaliaPayRegistration(
           registrationPk: event.registration!.pk,


### PR DESCRIPTION
Closes #374 .

### Summary
Fix pay button displaying when tpay is not allowed.

### How to test
Steps to test the changes you made:
1. Go to https://staging.thalia.nu/events/180/
2. Click on Register
3.  See that the pay button does not appear
