### PR TITLE
Add caching of S3 images

### DIFF
--- a/lib/config.dart
+++ b/lib/config.dart
@@ -13,6 +13,8 @@ const String apiHost = String.fromEnvironment(
   defaultValue: 'staging.thalia.nu',
 );
 
+String apiHostCDN = 'cdn.$apiHost';
+
 const String apiSecret = String.fromEnvironment(
   'THALIA_OAUTH_APP_SECRET',
   defaultValue:

--- a/lib/ui/widgets/cached_image.dart
+++ b/lib/ui/widgets/cached_image.dart
@@ -39,7 +39,8 @@ class CachedImage extends CachedNetworkImage {
           /// only used for authentication, not to identify the image, so the
           /// remaining path is a unique key.
           /// If the url is not from thalia.nu, use the full url as the key.
-          cacheKey: Uri.parse(imageUrl).host == config.apiHost
+          cacheKey: (Uri.parse(imageUrl).host == config.apiHost ||
+                  Uri.parse(imageUrl).host == config.apiHostCDN)
               ? Uri.parse(imageUrl).replace(query: '').toString()
               : imageUrl,
           fit: fit,


### PR DESCRIPTION
Closes #368 .

### Summary
Adds caching of S3 images.

### How to test
Steps to test the changes you made:
1. Go to anywhere with cached photos.
2. Come back and see that they are cached.
