### PR TITLE
Display current board

### DIFF
--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -21,11 +21,6 @@ class ListGroup {
       (since?.isBefore(DateTime.now()) ?? false) &&
       !(until?.isBefore(DateTime.now()) ?? false);
 
-  bool isCandidateBoard() =>
-      type == MemberGroupType.board &&
-      ((since?.isAfter(DateTime.now()) ?? false) ||
-          !(until?.isBefore(DateTime.now()) ?? true));
-
   const ListGroup(
     this.pk,
     this.name,

--- a/lib/models/group.dart
+++ b/lib/models/group.dart
@@ -18,7 +18,13 @@ class ListGroup {
 
   bool isActiveBoard() =>
       type == MemberGroupType.board &&
-      (until?.isAfter(DateTime.now()) ?? false);
+      (since?.isBefore(DateTime.now()) ?? false) &&
+      !(until?.isBefore(DateTime.now()) ?? false);
+
+  bool isCandidateBoard() =>
+      type == MemberGroupType.board &&
+      ((since?.isAfter(DateTime.now()) ?? false) ||
+          !(until?.isBefore(DateTime.now()) ?? true));
 
   const ListGroup(
     this.pk,

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -148,7 +148,7 @@ class GroupListScrollView extends StatelessWidget {
       : activeBoard = groups.firstWhereOrNull(
           (element) => element.isActiveBoard(),
         ),
-        groups = groups.toList(),
+        groups = groups.where((element) => !element.isActiveBoard()).toList(),
         super(key: key);
 
   @override

--- a/lib/ui/screens/groups_screen.dart
+++ b/lib/ui/screens/groups_screen.dart
@@ -148,7 +148,7 @@ class GroupListScrollView extends StatelessWidget {
       : activeBoard = groups.firstWhereOrNull(
           (element) => element.isActiveBoard(),
         ),
-        groups = groups.where((element) => !element.isActiveBoard()).toList(),
+        groups = groups.toList(),
         super(key: key);
 
   @override


### PR DESCRIPTION
Closes #399.

### Summary
Displaying current active board in large and also in the list.
Displaying candis in the list as well (and not in large anymore).

### How to test
Steps to test the changes you made:
1. Go to 'Groups'
2. Click on 'Boards'
