### PR TITLE
Cancelled and queued registrations in admin screen

### DIFF
--- a/lib/api/api_repository.dart
+++ b/lib/api/api_repository.dart
@@ -105,7 +105,7 @@ abstract class ApiRepository {
   /// total number of registrations that can be returned.
   /// Use `search` to filter on name, `ordering` to order with values in
   /// {'date', 'date_cancelled', 'queue_position', '-date', '-date_cancelled',
-  /// '-queue_position'}, and `cancelled` to filter on cancelled registrations.
+  /// '-queue_position'}, `cancelled` to filter on cancelled registrations, and `queued` to filter on queued registrations.
   Future<ListResponse<AdminEventRegistration>> getAdminEventRegistrations({
     required int pk,
     int? limit,
@@ -113,6 +113,7 @@ abstract class ApiRepository {
     String? search,
     String? ordering,
     bool? cancelled,
+    bool? queued,
   });
 
   /// Mark the user's registration for [Event] `pk` as present, using `token`.

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -417,6 +417,7 @@ class ConcrexitApiRepository implements ApiRepository {
     String? search,
     String? ordering,
     bool? cancelled,
+    bool? queued,
   }) async {
     assert(
       ordering == null ||
@@ -439,6 +440,7 @@ class ConcrexitApiRepository implements ApiRepository {
           if (ordering != null) 'ordering': ordering,
           if (search != null) 'search': search,
           if (cancelled != null) 'cancelled': cancelled.toString(),
+          if (queued != null) 'queued': queued.toString(),
         },
       );
       final response = await _handleExceptions(() => _client.get(uri));

--- a/lib/blocs/event_admin_cubit.dart
+++ b/lib/blocs/event_admin_cubit.dart
@@ -125,7 +125,10 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         limit: 999999999,
         cancelled: true,
         queued: false,
+<<<<<<< HEAD
         ordering: '-date_cancelled',
+=======
+>>>>>>> 1750326 (Implemented fetching from api using 'queued' parameter; added cancelled registrations and queued registrations to the admin state and cubit)
       );
       final queuedRegistrations = await api.getAdminEventRegistrations(
         pk: eventPk,
@@ -133,7 +136,10 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         limit: 999999999,
         cancelled: false,
         queued: true,
+<<<<<<< HEAD
         ordering: 'queue_position',
+=======
+>>>>>>> 1750326 (Implemented fetching from api using 'queued' parameter; added cancelled registrations and queued registrations to the admin state and cubit)
       );
 
       // Discard result if _searchQuery has
@@ -188,7 +194,10 @@ class EventAdminCubit extends Cubit<EventAdminState> {
           limit: 999999999,
           cancelled: true,
           queued: false,
+<<<<<<< HEAD
           ordering: '-date_cancelled',
+=======
+>>>>>>> 1750326 (Implemented fetching from api using 'queued' parameter; added cancelled registrations and queued registrations to the admin state and cubit)
         );
         final queuedRegistrations = await api.getAdminEventRegistrations(
           pk: eventPk,
@@ -196,7 +205,10 @@ class EventAdminCubit extends Cubit<EventAdminState> {
           limit: 999999999,
           cancelled: false,
           queued: true,
+<<<<<<< HEAD
           ordering: 'queue_position',
+=======
+>>>>>>> 1750326 (Implemented fetching from api using 'queued' parameter; added cancelled registrations and queued registrations to the admin state and cubit)
         );
 
         // Discard result if _searchQuery has

--- a/lib/blocs/event_admin_cubit.dart
+++ b/lib/blocs/event_admin_cubit.dart
@@ -14,6 +14,8 @@ class EventAdminState extends Equatable {
 
   /// These may be outdated when [isLoading] is true.
   final List<AdminEventRegistration> registrations;
+  final List<AdminEventRegistration> cancelledRegistrations;
+  final List<AdminEventRegistration> queuedRegistrations;
 
   final String? message;
   final bool isLoading;
@@ -24,6 +26,8 @@ class EventAdminState extends Equatable {
   const EventAdminState({
     required this.event,
     required this.registrations,
+    required this.cancelledRegistrations,
+    required this.queuedRegistrations,
     required this.isLoading,
     required this.message,
   }) : assert(
@@ -32,33 +36,53 @@ class EventAdminState extends Equatable {
         );
 
   @override
-  List<Object?> get props => [event, registrations, message, isLoading];
+  List<Object?> get props => [
+        event,
+        registrations,
+        cancelledRegistrations,
+        queuedRegistrations,
+        message,
+        isLoading
+      ];
 
   EventAdminState copyWith({
     AdminEvent? event,
     List<AdminEventRegistration>? registrations,
+    List<AdminEventRegistration>? cancelledRegistrations,
+    List<AdminEventRegistration>? queuedRegistrations,
     bool? isLoading,
     String? message,
   }) =>
       EventAdminState(
         event: event ?? this.event,
         registrations: registrations ?? this.registrations,
+        cancelledRegistrations:
+            cancelledRegistrations ?? this.cancelledRegistrations,
+        queuedRegistrations: queuedRegistrations ?? this.queuedRegistrations,
         isLoading: isLoading ?? this.isLoading,
         message: message ?? this.message,
       );
 
-  const EventAdminState.result({
-    required AdminEvent this.event,
-    required this.registrations,
-  })  : message = null,
+  const EventAdminState.result(
+      {required AdminEvent this.event,
+      required this.registrations,
+      required this.cancelledRegistrations,
+      required this.queuedRegistrations})
+      : message = null,
         isLoading = false;
 
-  const EventAdminState.loading({this.event, required this.registrations})
+  const EventAdminState.loading(
+      {this.event,
+      required this.registrations,
+      required this.cancelledRegistrations,
+      required this.queuedRegistrations})
       : message = null,
         isLoading = true;
 
   const EventAdminState.failure({required String this.message, this.event})
       : registrations = const [],
+        cancelledRegistrations = const [],
+        queuedRegistrations = const [],
         isLoading = false;
 }
 
@@ -78,7 +102,10 @@ class EventAdminCubit extends Cubit<EventAdminState> {
   EventAdminCubit(
     this.api, {
     required this.eventPk,
-  }) : super(const EventAdminState.loading(registrations: []));
+  }) : super(const EventAdminState.loading(
+            registrations: [],
+            cancelledRegistrations: [],
+            queuedRegistrations: []));
 
   Future<void> load() async {
     emit(state.copyWith(isLoading: true));
@@ -90,6 +117,23 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         search: query,
         limit: 999999999,
         cancelled: false,
+        queued: false,
+      );
+      final cancelledRegistrations = await api.getAdminEventRegistrations(
+        pk: eventPk,
+        search: query,
+        limit: 999999999,
+        cancelled: true,
+        queued: false,
+        ordering: '-date_cancelled',
+      );
+      final queuedRegistrations = await api.getAdminEventRegistrations(
+        pk: eventPk,
+        search: query,
+        limit: 999999999,
+        cancelled: false,
+        queued: true,
+        ordering: 'queue_position',
       );
 
       // Discard result if _searchQuery has
@@ -114,6 +158,8 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         emit(EventAdminState.result(
           event: event,
           registrations: registrations.results,
+          cancelledRegistrations: cancelledRegistrations.results,
+          queuedRegistrations: queuedRegistrations.results,
         ));
       }
     } on ApiException catch (exception) {
@@ -134,6 +180,23 @@ class EventAdminCubit extends Cubit<EventAdminState> {
           search: query,
           limit: 999999999,
           cancelled: false,
+          queued: false,
+        );
+        final cancelledRegistrations = await api.getAdminEventRegistrations(
+          pk: eventPk,
+          search: query,
+          limit: 999999999,
+          cancelled: true,
+          queued: false,
+          ordering: '-date_cancelled',
+        );
+        final queuedRegistrations = await api.getAdminEventRegistrations(
+          pk: eventPk,
+          search: query,
+          limit: 999999999,
+          cancelled: false,
+          queued: true,
+          ordering: 'queue_position',
         );
 
         // Discard result if _searchQuery has
@@ -156,6 +219,8 @@ class EventAdminCubit extends Cubit<EventAdminState> {
           emit(EventAdminState.result(
             event: event,
             registrations: registrations.results,
+            cancelledRegistrations: cancelledRegistrations.results,
+            queuedRegistrations: queuedRegistrations.results,
           ));
         }
       } on ApiException catch (exception) {
@@ -180,6 +245,8 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         emit(EventAdminState.loading(
           event: state.event,
           registrations: const [],
+          cancelledRegistrations: const [],
+          queuedRegistrations: const [],
         ));
       } else {
         _searchDebounceTimer = Timer(

--- a/lib/blocs/event_admin_cubit.dart
+++ b/lib/blocs/event_admin_cubit.dart
@@ -124,14 +124,12 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         search: query,
         limit: 999999999,
         cancelled: true,
-        queued: false,
         ordering: '-date_cancelled',
       );
       final queuedRegistrations = await api.getAdminEventRegistrations(
         pk: eventPk,
         search: query,
         limit: 999999999,
-        cancelled: false,
         queued: true,
         ordering: 'queue_position',
       );
@@ -187,14 +185,12 @@ class EventAdminCubit extends Cubit<EventAdminState> {
           search: query,
           limit: 999999999,
           cancelled: true,
-          queued: false,
           ordering: '-date_cancelled',
         );
         final queuedRegistrations = await api.getAdminEventRegistrations(
           pk: eventPk,
           search: query,
           limit: 999999999,
-          cancelled: false,
           queued: true,
           ordering: 'queue_position',
         );

--- a/lib/blocs/event_admin_cubit.dart
+++ b/lib/blocs/event_admin_cubit.dart
@@ -125,10 +125,7 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         limit: 999999999,
         cancelled: true,
         queued: false,
-<<<<<<< HEAD
         ordering: '-date_cancelled',
-=======
->>>>>>> 1750326 (Implemented fetching from api using 'queued' parameter; added cancelled registrations and queued registrations to the admin state and cubit)
       );
       final queuedRegistrations = await api.getAdminEventRegistrations(
         pk: eventPk,
@@ -136,10 +133,7 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         limit: 999999999,
         cancelled: false,
         queued: true,
-<<<<<<< HEAD
         ordering: 'queue_position',
-=======
->>>>>>> 1750326 (Implemented fetching from api using 'queued' parameter; added cancelled registrations and queued registrations to the admin state and cubit)
       );
 
       // Discard result if _searchQuery has
@@ -194,10 +188,7 @@ class EventAdminCubit extends Cubit<EventAdminState> {
           limit: 999999999,
           cancelled: true,
           queued: false,
-<<<<<<< HEAD
           ordering: '-date_cancelled',
-=======
->>>>>>> 1750326 (Implemented fetching from api using 'queued' parameter; added cancelled registrations and queued registrations to the admin state and cubit)
         );
         final queuedRegistrations = await api.getAdminEventRegistrations(
           pk: eventPk,
@@ -205,10 +196,7 @@ class EventAdminCubit extends Cubit<EventAdminState> {
           limit: 999999999,
           cancelled: false,
           queued: true,
-<<<<<<< HEAD
           ordering: 'queue_position',
-=======
->>>>>>> 1750326 (Implemented fetching from api using 'queued' parameter; added cancelled registrations and queued registrations to the admin state and cubit)
         );
 
         // Discard result if _searchQuery has

--- a/lib/models/event_registration.dart
+++ b/lib/models/event_registration.dart
@@ -76,6 +76,7 @@ class AdminEventRegistration implements EventRegistration {
   final bool present;
   final int? queuePosition;
   final DateTime date;
+  final DateTime? dateCancelled;
   final Payment? payment;
 
   bool get isInQueue => queuePosition != null;
@@ -89,6 +90,7 @@ class AdminEventRegistration implements EventRegistration {
     this.present,
     this.queuePosition,
     this.date,
+    this.dateCancelled,
     this.payment,
   ) : assert(
           member != null || name != null,
@@ -103,6 +105,7 @@ class AdminEventRegistration implements EventRegistration {
         newPresent,
         queuePosition,
         date,
+        dateCancelled,
         payment,
       );
 
@@ -114,6 +117,7 @@ class AdminEventRegistration implements EventRegistration {
         present,
         queuePosition,
         date,
+        dateCancelled,
         newPayment,
       );
 

--- a/lib/models/event_registration.g.dart
+++ b/lib/models/event_registration.g.dart
@@ -59,6 +59,9 @@ AdminEventRegistration _$AdminEventRegistrationFromJson(
       json['present'] as bool,
       json['queue_position'] as int?,
       DateTime.parse(json['date'] as String),
+      json['date_cancelled'] == null
+          ? null
+          : DateTime.parse(json['date_cancelled'] as String),
       json['payment'] == null
           ? null
           : Payment.fromJson(json['payment'] as Map<String, dynamic>),
@@ -73,5 +76,6 @@ Map<String, dynamic> _$AdminEventRegistrationToJson(
       'present': instance.present,
       'queue_position': instance.queuePosition,
       'date': instance.date.toIso8601String(),
+      'date_cancelled': instance.dateCancelled?.toIso8601String(),
       'payment': instance.payment,
     };

--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -129,11 +129,16 @@ class _EventAdminScreenState extends State<EventAdminScreen> {
                     tooltip: 'Show presence QR code',
                   ),
                 ],
-                bottom: const TabBar(tabs: [
-                  Tab(text: 'QUEUED'),
-                  Tab(text: 'REGISTERED'),
-                  Tab(text: 'CANCELLED'),
-                ]),
+                bottom: TabBar(
+                  indicatorColor: Theme.of(context).colorScheme.primary,
+                  labelColor: Theme.of(context).colorScheme.primary,
+                  unselectedLabelColor: Theme.of(context).colorScheme.onPrimary,
+                  tabs: const [
+                    Tab(text: 'QUEUED'),
+                    Tab(text: 'REGISTERED'),
+                    Tab(text: 'CANCELLED'),
+                  ],
+                ),
               ),
               body: RefreshIndicator(
                 onRefresh: () async {

--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -129,14 +129,11 @@ class _EventAdminScreenState extends State<EventAdminScreen> {
                     tooltip: 'Show presence QR code',
                   ),
                 ],
-                bottom: TabBar(
-                  indicatorColor: Theme.of(context).colorScheme.primary,
-                  tabs: const [
-                    Tab(text: 'QUEUED'),
-                    Tab(text: 'REGISTERED'),
-                    Tab(text: 'CANCELLED'),
-                  ],
-                ),
+                bottom: const TabBar(tabs: [
+                  Tab(text: 'QUEUED'),
+                  Tab(text: 'REGISTERED'),
+                  Tab(text: 'CANCELLED'),
+                ]),
               ),
               body: RefreshIndicator(
                 onRefresh: () async {

--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -131,8 +131,6 @@ class _EventAdminScreenState extends State<EventAdminScreen> {
                 ],
                 bottom: TabBar(
                   indicatorColor: Theme.of(context).colorScheme.primary,
-                  labelColor: Theme.of(context).colorScheme.primary,
-                  unselectedLabelColor: Theme.of(context).colorScheme.onPrimary,
                   tabs: const [
                     Tab(text: 'QUEUED'),
                     Tab(text: 'REGISTERED'),

--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -132,9 +132,9 @@ class _EventAdminScreenState extends State<EventAdminScreen> {
                 bottom: TabBar(
                   indicatorColor: Theme.of(context).colorScheme.primary,
                   tabs: const [
-                    Tab(text: 'QUEUED'),
-                    Tab(text: 'REGISTERED'),
-                    Tab(text: 'CANCELLED'),
+                    Tab(text: 'Queued'),
+                    Tab(text: 'Registered'),
+                    Tab(text: 'Cancelled'),
                   ],
                 ),
               ),

--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -152,39 +152,50 @@ class _EventAdminScreenState extends State<EventAdminScreen> {
                       return const Center(child: CircularProgressIndicator());
                     } else {
                       return TabBarView(children: [
-                        Scrollbar(
-                          child: ListView.separated(
-                            key: const PageStorageKey('event-admin'),
-                            itemBuilder: (context, index) =>
-                                _QueuedRegistrationTile(
-                              registration: state.queuedRegistrations[index],
+                        if (state.queuedRegistrations.isEmpty)
+                          const ErrorCenter('No queued registrations found')
+                        else
+                          Scrollbar(
+                            child: ListView.separated(
+                              key: const PageStorageKey('event-admin'),
+                              itemBuilder: (context, index) =>
+                                  _QueuedRegistrationTile(
+                                registration: state.queuedRegistrations[index],
+                              ),
+                              separatorBuilder: (_, __) => const Divider(),
+                              itemCount: state.queuedRegistrations.length,
                             ),
-                            separatorBuilder: (_, __) => const Divider(),
-                            itemCount: state.queuedRegistrations.length,
                           ),
-                        ),
-                        Scrollbar(
-                          child: ListView.separated(
-                            key: const PageStorageKey('event-admin'),
-                            itemBuilder: (context, index) => _RegistrationTile(
-                              registration: state.registrations[index],
-                              requiresPayment: state.event!.paymentIsRequired,
+                        if (state.registrations.isEmpty)
+                          const ErrorCenter('No registrations found')
+                        else
+                          Scrollbar(
+                            child: ListView.separated(
+                              key: const PageStorageKey('event-admin'),
+                              itemBuilder: (context, index) =>
+                                  _RegistrationTile(
+                                registration: state.registrations[index],
+                                requiresPayment: state.event!.paymentIsRequired,
+                              ),
+                              separatorBuilder: (_, __) => const Divider(),
+                              itemCount: state.registrations.length,
                             ),
-                            separatorBuilder: (_, __) => const Divider(),
-                            itemCount: state.registrations.length,
                           ),
-                        ),
-                        Scrollbar(
-                          child: ListView.separated(
-                            key: const PageStorageKey('event-admin'),
-                            itemBuilder: (context, index) =>
-                                _CancelledRegistrationTile(
-                              registration: state.cancelledRegistrations[index],
+                        if (state.cancelledRegistrations.isEmpty)
+                          const ErrorCenter('No cancelled registrations found')
+                        else
+                          Scrollbar(
+                            child: ListView.separated(
+                              key: const PageStorageKey('event-admin'),
+                              itemBuilder: (context, index) =>
+                                  _CancelledRegistrationTile(
+                                registration:
+                                    state.cancelledRegistrations[index],
+                              ),
+                              separatorBuilder: (_, __) => const Divider(),
+                              itemCount: state.cancelledRegistrations.length,
                             ),
-                            separatorBuilder: (_, __) => const Divider(),
-                            itemCount: state.cancelledRegistrations.length,
                           ),
-                        ),
                       ]);
                     }
                   },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -66,8 +66,10 @@ packages:
     description:
       name: async
       sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
       url: "https://pub.dev"
     source: hosted
+    version: "2.10.0"
     version: "2.10.0"
   bloc:
     dependency: transitive
@@ -189,9 +191,8 @@ packages:
       name: characters
       sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
       url: "https://pub.dev"
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
-      url: "https://pub.dev"
     source: hosted
+    version: "1.2.1"
     version: "1.2.1"
   checked_yaml:
     dependency: transitive
@@ -741,9 +742,8 @@ packages:
       name: js
       sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
     source: hosted
+    version: "0.6.5"
     version: "0.6.5"
   json_annotation:
     dependency: "direct main"
@@ -803,9 +803,8 @@ packages:
       name: meta
       sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
-      url: "https://pub.dev"
     source: hosted
+    version: "1.8.0"
     version: "1.8.0"
   mime:
     dependency: "direct main"
@@ -893,9 +892,8 @@ packages:
       name: path
       sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
-      url: "https://pub.dev"
     source: hosted
+    version: "1.8.2"
     version: "1.8.2"
   path_provider:
     dependency: "direct main"
@@ -1424,9 +1422,8 @@ packages:
       name: webdriver
       sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
       url: "https://pub.dev"
-      sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
-      url: "https://pub.dev"
     source: hosted
+    version: "3.0.1"
     version: "3.0.1"
   win32:
     dependency: transitive

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,6 +7,8 @@ packages:
       name: _fe_analyzer_shared
       sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
       url: "https://pub.dev"
+      sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
+      url: "https://pub.dev"
     source: hosted
     version: "61.0.0"
   _flutterfire_internals:
@@ -29,6 +31,8 @@ packages:
     dependency: transitive
     description:
       name: analyzer
+      sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
+      url: "https://pub.dev"
       sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
       url: "https://pub.dev"
     source: hosted
@@ -62,7 +66,6 @@ packages:
     description:
       name: async
       sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
       url: "https://pub.dev"
     source: hosted
     version: "2.10.0"
@@ -72,14 +75,14 @@ packages:
       name: bloc
       sha256: "658a5ae59edcf1e58aac98b000a71c762ad8f46f1394c34a52050cafb3e11a80"
       url: "https://pub.dev"
+      sha256: "658a5ae59edcf1e58aac98b000a71c762ad8f46f1394c34a52050cafb3e11a80"
+      url: "https://pub.dev"
     source: hosted
     version: "8.1.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
-      url: "https://pub.dev"
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
@@ -96,8 +99,6 @@ packages:
     dependency: transitive
     description:
       name: build_config
-      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
-      url: "https://pub.dev"
       sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
       url: "https://pub.dev"
     source: hosted
@@ -140,8 +141,6 @@ packages:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
       url: "https://pub.dev"
-      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -182,14 +181,14 @@ packages:
       name: carousel_slider
       sha256: "9c695cc963bf1d04a47bd6021f68befce8970bcd61d24938e1fb0918cf5d9c42"
       url: "https://pub.dev"
-      sha256: "9c695cc963bf1d04a47bd6021f68befce8970bcd61d24938e1fb0918cf5d9c42"
-      url: "https://pub.dev"
     source: hosted
     version: "4.2.1"
   characters:
     dependency: transitive
     description:
       name: characters
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
       sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
       url: "https://pub.dev"
     source: hosted
@@ -200,14 +199,14 @@ packages:
       name: checked_yaml
       sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
       url: "https://pub.dev"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
-      url: "https://pub.dev"
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
@@ -232,8 +231,6 @@ packages:
     dependency: transitive
     description:
       name: convert
-      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
-      url: "https://pub.dev"
       sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
       url: "https://pub.dev"
     source: hosted
@@ -276,16 +273,12 @@ packages:
       name: equatable
       sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
       url: "https://pub.dev"
-      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
-      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
-      url: "https://pub.dev"
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
@@ -302,8 +295,6 @@ packages:
     dependency: transitive
     description:
       name: file
-      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
-      url: "https://pub.dev"
       sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
       url: "https://pub.dev"
     source: hosted
@@ -354,6 +345,8 @@ packages:
       name: firebase_core_platform_interface
       sha256: "0df0a064ab0cad7f8836291ca6f3272edd7b83ad5b3540478ee46a0849d8022b"
       url: "https://pub.dev"
+      sha256: "0df0a064ab0cad7f8836291ca6f3272edd7b83ad5b3540478ee46a0849d8022b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   firebase_core_web:
@@ -394,8 +387,6 @@ packages:
       name: fixnum
       sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
-      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
-      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   flutter:
@@ -407,6 +398,8 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
+      sha256: "434951eea948dbe87f737b674281465f610b8259c16c097b8163ce138749a775"
+      url: "https://pub.dev"
       sha256: "434951eea948dbe87f737b674281465f610b8259c16c097b8163ce138749a775"
       url: "https://pub.dev"
     source: hosted
@@ -515,6 +508,8 @@ packages:
       name: flutter_web_auth_2_platform_interface
       sha256: "91ff7f0bf4ca530aabf857433db2fbcc3d1b8e3c5347ecf58e5ace8f9d29edb0"
       url: "https://pub.dev"
+      sha256: "91ff7f0bf4ca530aabf857433db2fbcc3d1b8e3c5347ecf58e5ace8f9d29edb0"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   flutter_web_plugins:
@@ -536,8 +531,6 @@ packages:
       name: frontend_server_client
       sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
       url: "https://pub.dev"
-      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
-      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   fuchsia_remote_debug_protocol:
@@ -557,6 +550,8 @@ packages:
     dependency: transitive
     description:
       name: glob
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
       sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
       url: "https://pub.dev"
     source: hosted
@@ -583,6 +578,8 @@ packages:
       name: graphs
       sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
       url: "https://pub.dev"
+      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   html:
@@ -607,8 +604,6 @@ packages:
       name: http_multi_server
       sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
       url: "https://pub.dev"
-      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
-      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
@@ -617,14 +612,14 @@ packages:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.dev"
-      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
-      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   image:
     dependency: transitive
     description:
       name: image
+      sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
+      url: "https://pub.dev"
       sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
       url: "https://pub.dev"
     source: hosted
@@ -728,14 +723,14 @@ packages:
       name: intl
       sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
       url: "https://pub.dev"
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
+      url: "https://pub.dev"
     source: hosted
     version: "0.18.1"
   io:
     dependency: transitive
     description:
       name: io
-      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
-      url: "https://pub.dev"
       sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
       url: "https://pub.dev"
     source: hosted
@@ -746,12 +741,16 @@ packages:
       name: js
       sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
       sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
       url: "https://pub.dev"
     source: hosted
@@ -778,6 +777,8 @@ packages:
       name: logging
       sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
       url: "https://pub.dev"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   matcher:
@@ -802,14 +803,14 @@ packages:
       name: meta
       sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: "direct main"
     description:
       name: mime
-      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
-      url: "https://pub.dev"
       sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
       url: "https://pub.dev"
     source: hosted
@@ -826,8 +827,6 @@ packages:
     dependency: transitive
     description:
       name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
       url: "https://pub.dev"
     source: hosted
@@ -862,16 +861,12 @@ packages:
       name: overlay_support
       sha256: fc39389bfd94e6985e1e13b2a88a125fc4027608485d2d4e2847afe1b2bb339c
       url: "https://pub.dev"
-      sha256: fc39389bfd94e6985e1e13b2a88a125fc4027608485d2d4e2847afe1b2bb339c
-      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
-      url: "https://pub.dev"
       sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
       url: "https://pub.dev"
     source: hosted
@@ -890,14 +885,14 @@ packages:
       name: package_info_plus_platform_interface
       sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
       url: "https://pub.dev"
-      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
-      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   path:
     dependency: transitive
     description:
       name: path
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
       sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
@@ -964,16 +959,12 @@ packages:
       name: photo_view
       sha256: "8036802a00bae2a78fc197af8a158e3e2f7b500561ed23b4c458107685e645bb"
       url: "https://pub.dev"
-      sha256: "8036802a00bae2a78fc197af8a158e3e2f7b500561ed23b4c458107685e645bb"
-      url: "https://pub.dev"
     source: hosted
     version: "0.14.0"
   platform:
     dependency: transitive
     description:
       name: platform
-      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
-      url: "https://pub.dev"
       sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
       url: "https://pub.dev"
     source: hosted
@@ -1000,16 +991,12 @@ packages:
       name: pool
       sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
       url: "https://pub.dev"
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
-      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   process:
     dependency: transitive
     description:
       name: process
-      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
-      url: "https://pub.dev"
       sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
       url: "https://pub.dev"
     source: hosted
@@ -1020,8 +1007,6 @@ packages:
       name: provider
       sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
       url: "https://pub.dev"
-      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
-      url: "https://pub.dev"
     source: hosted
     version: "6.0.5"
   pub_semver:
@@ -1030,12 +1015,16 @@ packages:
       name: pub_semver
       sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
       url: "https://pub.dev"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
+      sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
+      url: "https://pub.dev"
       sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
       url: "https://pub.dev"
     source: hosted
@@ -1060,8 +1049,6 @@ packages:
     dependency: transitive
     description:
       name: rxdart
-      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
-      url: "https://pub.dev"
       sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
       url: "https://pub.dev"
     source: hosted
@@ -1160,12 +1147,16 @@ packages:
       name: shelf
       sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
       url: "https://pub.dev"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
       sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
       url: "https://pub.dev"
     source: hosted
@@ -1221,14 +1212,14 @@ packages:
       name: stack_trace
       sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
-      url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
   sticky_headers:
     dependency: "direct main"
     description:
       name: sticky_headers
+      sha256: "9b3dd2cb0fd6a7038170af3261f855660cbb241cb56c501452cb8deed7023ede"
+      url: "https://pub.dev"
       sha256: "9b3dd2cb0fd6a7038170af3261f855660cbb241cb56c501452cb8deed7023ede"
       url: "https://pub.dev"
     source: hosted
@@ -1239,16 +1230,12 @@ packages:
       name: stream_channel
       sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
-      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
-      url: "https://pub.dev"
       sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
       url: "https://pub.dev"
     source: hosted
@@ -1259,16 +1246,12 @@ packages:
       name: string_scanner
       sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
-      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
-      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   sync_http:
     dependency: transitive
     description:
       name: sync_http
-      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
-      url: "https://pub.dev"
       sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
       url: "https://pub.dev"
     source: hosted
@@ -1279,14 +1262,14 @@ packages:
       name: synchronized
       sha256: "33b31b6beb98100bf9add464a36a8dd03eb10c7a8cf15aeec535e9b054aaf04b"
       url: "https://pub.dev"
+      sha256: "33b31b6beb98100bf9add464a36a8dd03eb10c7a8cf15aeec535e9b054aaf04b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
-      url: "https://pub.dev"
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
@@ -1303,8 +1286,6 @@ packages:
     dependency: transitive
     description:
       name: timing
-      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
-      url: "https://pub.dev"
       sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
       url: "https://pub.dev"
     source: hosted
@@ -1395,16 +1376,12 @@ packages:
       name: uuid
       sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
       url: "https://pub.dev"
-      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
-      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
-      url: "https://pub.dev"
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
@@ -1439,14 +1416,14 @@ packages:
       name: web_socket_channel
       sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
-      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
-      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
+      sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
+      url: "https://pub.dev"
       sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
       url: "https://pub.dev"
     source: hosted
@@ -1463,8 +1440,6 @@ packages:
     dependency: transitive
     description:
       name: window_to_front
-      sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
-      url: "https://pub.dev"
       sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
       url: "https://pub.dev"
     source: hosted
@@ -1489,6 +1464,8 @@ packages:
     dependency: transitive
     description:
       name: yaml
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
       sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
       url: "https://pub.dev"
     source: hosted

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,7 +5,7 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: ae92f5d747aee634b87f89d9946000c2de774be1d6ac3e58268224348cd0101a
+      sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
       url: "https://pub.dev"
     source: hosted
     version: "61.0.0"
@@ -29,7 +29,7 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: ea3d8652bda62982addfd92fdc2d0214e5f82e43325104990d4f4c4a2a313562
+      sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
       url: "https://pub.dev"
     source: hosted
     version: "5.13.0"
@@ -61,15 +61,16 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.10.0"
   bloc:
     dependency: transitive
     description:
       name: bloc
-      sha256: "3820f15f502372d979121de1f6b97bfcf1630ebff8fe1d52fb2b0bfa49be5b49"
+      sha256: "658a5ae59edcf1e58aac98b000a71c762ad8f46f1394c34a52050cafb3e11a80"
       url: "https://pub.dev"
     source: hosted
     version: "8.1.2"
@@ -77,6 +78,8 @@ packages:
     dependency: transitive
     description:
       name: boolean_selector
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
       sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
       url: "https://pub.dev"
     source: hosted
@@ -93,6 +96,8 @@ packages:
     dependency: transitive
     description:
       name: build_config
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
       sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
       url: "https://pub.dev"
     source: hosted
@@ -135,6 +140,8 @@ packages:
       name: built_collection
       sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
       url: "https://pub.dev"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
@@ -175,21 +182,23 @@ packages:
       name: carousel_slider
       sha256: "9c695cc963bf1d04a47bd6021f68befce8970bcd61d24938e1fb0918cf5d9c42"
       url: "https://pub.dev"
+      sha256: "9c695cc963bf1d04a47bd6021f68befce8970bcd61d24938e1fb0918cf5d9c42"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: feb6bed21949061731a7a75fc5d2aa727cf160b91af9a3e464c5e3a32e28b5ff
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
       url: "https://pub.dev"
     source: hosted
     version: "2.0.3"
@@ -197,6 +206,8 @@ packages:
     dependency: transitive
     description:
       name: clock
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
       sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
       url: "https://pub.dev"
     source: hosted
@@ -221,6 +232,8 @@ packages:
     dependency: transitive
     description:
       name: convert
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
       sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
       url: "https://pub.dev"
     source: hosted
@@ -263,12 +276,16 @@ packages:
       name: equatable
       sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
       url: "https://pub.dev"
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
       sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
       url: "https://pub.dev"
     source: hosted
@@ -285,6 +302,8 @@ packages:
     dependency: transitive
     description:
       name: file
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
       sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
       url: "https://pub.dev"
     source: hosted
@@ -333,7 +352,7 @@ packages:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
-      sha256: b63e3be6c96ef5c33bdec1aab23c91eb00696f6452f0519401d640938c94cba2
+      sha256: "0df0a064ab0cad7f8836291ca6f3272edd7b83ad5b3540478ee46a0849d8022b"
       url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
@@ -375,6 +394,8 @@ packages:
       name: fixnum
       sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
       url: "https://pub.dev"
+      sha256: "25517a4deb0c03aa0f32fd12db525856438902d9c16536311e76cdc57b31d7d1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
   flutter:
@@ -386,7 +407,7 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: e74efb89ee6945bcbce74a5b3a5a3376b088e5f21f55c263fc38cbdc6237faae
+      sha256: "434951eea948dbe87f737b674281465f610b8259c16c097b8163ce138749a775"
       url: "https://pub.dev"
     source: hosted
     version: "8.1.3"
@@ -492,7 +513,7 @@ packages:
     dependency: transitive
     description:
       name: flutter_web_auth_2_platform_interface
-      sha256: f6fa7059ff3428c19cd756c02fef8eb0147131c7e64591f9060c90b5ab84f094
+      sha256: "91ff7f0bf4ca530aabf857433db2fbcc3d1b8e3c5347ecf58e5ace8f9d29edb0"
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
@@ -515,6 +536,8 @@ packages:
       name: frontend_server_client
       sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
       url: "https://pub.dev"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   fuchsia_remote_debug_protocol:
@@ -534,7 +557,7 @@ packages:
     dependency: transitive
     description:
       name: glob
-      sha256: "0e7014b3b7d4dac1ca4d6114f82bf1782ee86745b9b42a92c9289c23d8a0ab63"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
@@ -558,7 +581,7 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: aedc5a15e78fc65a6e23bcd927f24c64dd995062bcd1ca6eda65a3cff92a4d19
+      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
@@ -584,6 +607,8 @@ packages:
       name: http_multi_server
       sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
       url: "https://pub.dev"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
@@ -592,13 +617,15 @@ packages:
       name: http_parser
       sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.dev"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   image:
     dependency: transitive
     description:
       name: image
-      sha256: a72242c9a0ffb65d03de1b7113bc4e189686fc07c7147b8b41811d0dd0e0d9bf
+      sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
       url: "https://pub.dev"
     source: hosted
     version: "4.0.17"
@@ -699,7 +726,7 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3bc132a9dbce73a7e4a21a17d06e1878839ffbf975568bc875c60537824b0c4d"
+      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
       url: "https://pub.dev"
     source: hosted
     version: "0.18.1"
@@ -709,21 +736,23 @@ packages:
       name: io
       sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
       url: "https://pub.dev"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      sha256: f2c445dce49627136094980615a031419f7f3eb393237e4ecd97ac15dea343f3
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.7"
+    version: "0.6.5"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: b10a7b2ff83d83c777edba3c6a0f97045ddadd56c944e1a23a3fdf43a1bf4467
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
       url: "https://pub.dev"
     source: hosted
     version: "4.8.1"
@@ -747,7 +776,7 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "623a88c9594aa774443aa3eb2d41807a48486b5613e67599fb4c41c0ad47c340"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
@@ -771,14 +800,16 @@ packages:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.8.0"
   mime:
     dependency: "direct main"
     description:
       name: mime
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
       sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
       url: "https://pub.dev"
     source: hosted
@@ -795,6 +826,8 @@ packages:
     dependency: transitive
     description:
       name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
       sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
       url: "https://pub.dev"
     source: hosted
@@ -829,12 +862,16 @@ packages:
       name: overlay_support
       sha256: fc39389bfd94e6985e1e13b2a88a125fc4027608485d2d4e2847afe1b2bb339c
       url: "https://pub.dev"
+      sha256: fc39389bfd94e6985e1e13b2a88a125fc4027608485d2d4e2847afe1b2bb339c
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   package_config:
     dependency: transitive
     description:
       name: package_config
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
       sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
       url: "https://pub.dev"
     source: hosted
@@ -853,16 +890,18 @@ packages:
       name: package_info_plus_platform_interface
       sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
       url: "https://pub.dev"
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.8.2"
   path_provider:
     dependency: "direct main"
     description:
@@ -925,12 +964,16 @@ packages:
       name: photo_view
       sha256: "8036802a00bae2a78fc197af8a158e3e2f7b500561ed23b4c458107685e645bb"
       url: "https://pub.dev"
+      sha256: "8036802a00bae2a78fc197af8a158e3e2f7b500561ed23b4c458107685e645bb"
+      url: "https://pub.dev"
     source: hosted
     version: "0.14.0"
   platform:
     dependency: transitive
     description:
       name: platform
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
       sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
       url: "https://pub.dev"
     source: hosted
@@ -957,12 +1000,16 @@ packages:
       name: pool
       sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
       url: "https://pub.dev"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   process:
     dependency: transitive
     description:
       name: process
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
       sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
       url: "https://pub.dev"
     source: hosted
@@ -973,13 +1020,15 @@ packages:
       name: provider
       sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
       url: "https://pub.dev"
+      sha256: cdbe7530b12ecd9eb455bdaa2fcb8d4dad22e80b8afb4798b41479d5ce26847f
+      url: "https://pub.dev"
     source: hosted
     version: "6.0.5"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      sha256: "40d3ab1bbd474c4c2328c91e3a7df8c6dd629b79ece4c4bd04bee496a224fb0c"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
@@ -987,7 +1036,7 @@ packages:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: c63b2876e58e194e4b0828fcb080ad0e06d051cb607a6be51a9e084f47cb9367
+      sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
       url: "https://pub.dev"
     source: hosted
     version: "1.2.3"
@@ -1011,6 +1060,8 @@ packages:
     dependency: transitive
     description:
       name: rxdart
+      sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
+      url: "https://pub.dev"
       sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"
       url: "https://pub.dev"
     source: hosted
@@ -1107,7 +1158,7 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
@@ -1115,7 +1166,7 @@ packages:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: "9ca081be41c60190ebcb4766b2486a7d50261db7bd0f5d9615f2d653637a84c1"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
@@ -1170,21 +1221,24 @@ packages:
       name: stack_trace
       sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
       url: "https://pub.dev"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
   sticky_headers:
     dependency: "direct main"
     description:
-      path: "."
-      ref: a3f6cba75471ba16462e5def50794c1c0ce53dfc
-      resolved-ref: a3f6cba75471ba16462e5def50794c1c0ce53dfc
-      url: "https://github.com/JAicewizard/flutter_sticky_headers"
-    source: git
+      name: sticky_headers
+      sha256: "9b3dd2cb0fd6a7038170af3261f855660cbb241cb56c501452cb8deed7023ede"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.3.0+2"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
       sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
       url: "https://pub.dev"
     source: hosted
@@ -1195,12 +1249,16 @@ packages:
       name: stream_transform
       sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
       url: "https://pub.dev"
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
       sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.dev"
     source: hosted
@@ -1211,13 +1269,15 @@ packages:
       name: sync_http
       sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
       url: "https://pub.dev"
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "5fcbd27688af6082f5abd611af56ee575342c30e87541d0245f7ff99faa02c60"
+      sha256: "33b31b6beb98100bf9add464a36a8dd03eb10c7a8cf15aeec535e9b054aaf04b"
       url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
@@ -1225,6 +1285,8 @@ packages:
     dependency: transitive
     description:
       name: term_glyph
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
       sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
       url: "https://pub.dev"
     source: hosted
@@ -1241,6 +1303,8 @@ packages:
     dependency: transitive
     description:
       name: timing
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
       sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
       url: "https://pub.dev"
     source: hosted
@@ -1331,12 +1395,16 @@ packages:
       name: uuid
       sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
       url: "https://pub.dev"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
       sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
@@ -1371,16 +1439,18 @@ packages:
       name: web_socket_channel
       sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
       url: "https://pub.dev"
+      sha256: d88238e5eac9a42bb43ca4e721edba3c08c6354d4a53063afaa568516217621b
+      url: "https://pub.dev"
     source: hosted
     version: "2.4.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "3c923e918918feeb90c4c9fdf1fe39220fa4c0e8e2c0fffaded174498ef86c49"
+      sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   win32:
     dependency: transitive
     description:
@@ -1393,6 +1463,8 @@ packages:
     dependency: transitive
     description:
       name: window_to_front
+      sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
+      url: "https://pub.dev"
       sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
       url: "https://pub.dev"
     source: hosted
@@ -1417,7 +1489,7 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "75769501ea3489fca56601ff33454fe45507ea3bfb014161abc3b43ae25989d5"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,8 +7,6 @@ packages:
       name: _fe_analyzer_shared
       sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
       url: "https://pub.dev"
-      sha256: a36ec4843dc30ea6bf652bf25e3448db6c5e8bcf4aa55f063a5d1dad216d8214
-      url: "https://pub.dev"
     source: hosted
     version: "61.0.0"
   _flutterfire_internals:
@@ -31,8 +29,6 @@ packages:
     dependency: transitive
     description:
       name: analyzer
-      sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
-      url: "https://pub.dev"
       sha256: cc4242565347e98424ce9945c819c192ec0838cb9d1f6aa4a97cc96becbc5b27
       url: "https://pub.dev"
     source: hosted
@@ -66,17 +62,13 @@ packages:
     description:
       name: async
       sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
     version: "2.10.0"
   bloc:
     dependency: transitive
     description:
       name: bloc
-      sha256: "658a5ae59edcf1e58aac98b000a71c762ad8f46f1394c34a52050cafb3e11a80"
-      url: "https://pub.dev"
       sha256: "658a5ae59edcf1e58aac98b000a71c762ad8f46f1394c34a52050cafb3e11a80"
       url: "https://pub.dev"
     source: hosted
@@ -193,13 +185,10 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
-    version: "1.2.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
-      url: "https://pub.dev"
       sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
       url: "https://pub.dev"
     source: hosted
@@ -346,8 +335,6 @@ packages:
       name: firebase_core_platform_interface
       sha256: "0df0a064ab0cad7f8836291ca6f3272edd7b83ad5b3540478ee46a0849d8022b"
       url: "https://pub.dev"
-      sha256: "0df0a064ab0cad7f8836291ca6f3272edd7b83ad5b3540478ee46a0849d8022b"
-      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   firebase_core_web:
@@ -399,8 +386,6 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: "434951eea948dbe87f737b674281465f610b8259c16c097b8163ce138749a775"
-      url: "https://pub.dev"
       sha256: "434951eea948dbe87f737b674281465f610b8259c16c097b8163ce138749a775"
       url: "https://pub.dev"
     source: hosted
@@ -509,8 +494,6 @@ packages:
       name: flutter_web_auth_2_platform_interface
       sha256: "91ff7f0bf4ca530aabf857433db2fbcc3d1b8e3c5347ecf58e5ace8f9d29edb0"
       url: "https://pub.dev"
-      sha256: "91ff7f0bf4ca530aabf857433db2fbcc3d1b8e3c5347ecf58e5ace8f9d29edb0"
-      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   flutter_web_plugins:
@@ -553,8 +536,6 @@ packages:
       name: glob
       sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
       url: "https://pub.dev"
-      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
-      url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
   go_router:
@@ -577,8 +558,6 @@ packages:
     dependency: transitive
     description:
       name: graphs
-      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
-      url: "https://pub.dev"
       sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
       url: "https://pub.dev"
     source: hosted
@@ -619,8 +598,6 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
-      url: "https://pub.dev"
       sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
       url: "https://pub.dev"
     source: hosted
@@ -724,8 +701,6 @@ packages:
       name: intl
       sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
       url: "https://pub.dev"
-      sha256: a3715e3bc90294e971cb7dc063fbf3cd9ee0ebf8604ffeafabd9e6f16abbdbe6
-      url: "https://pub.dev"
     source: hosted
     version: "0.18.1"
   io:
@@ -744,13 +719,10 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.5"
-    version: "0.6.5"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
-      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
-      url: "https://pub.dev"
       sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
       url: "https://pub.dev"
     source: hosted
@@ -775,8 +747,6 @@ packages:
     dependency: transitive
     description:
       name: logging
-      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
-      url: "https://pub.dev"
       sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
       url: "https://pub.dev"
     source: hosted
@@ -804,7 +774,6 @@ packages:
       sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
     version: "1.8.0"
   mime:
     dependency: "direct main"
@@ -893,7 +862,6 @@ packages:
       sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
     version: "1.8.2"
   path_provider:
     dependency: "direct main"
@@ -1013,16 +981,12 @@ packages:
       name: pub_semver
       sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
       url: "https://pub.dev"
-      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
-      url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
-      url: "https://pub.dev"
       sha256: ec85d7d55339d85f44ec2b682a82fea340071e8978257e5a43e69f79e98ef50c
       url: "https://pub.dev"
     source: hosted
@@ -1145,16 +1109,12 @@ packages:
       name: shelf
       sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
       url: "https://pub.dev"
-      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
-      url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
-      url: "https://pub.dev"
       sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
       url: "https://pub.dev"
     source: hosted
@@ -1218,8 +1178,6 @@ packages:
       name: sticky_headers
       sha256: "9b3dd2cb0fd6a7038170af3261f855660cbb241cb56c501452cb8deed7023ede"
       url: "https://pub.dev"
-      sha256: "9b3dd2cb0fd6a7038170af3261f855660cbb241cb56c501452cb8deed7023ede"
-      url: "https://pub.dev"
     source: hosted
     version: "0.3.0+2"
   stream_channel:
@@ -1258,8 +1216,6 @@ packages:
     dependency: transitive
     description:
       name: synchronized
-      sha256: "33b31b6beb98100bf9add464a36a8dd03eb10c7a8cf15aeec535e9b054aaf04b"
-      url: "https://pub.dev"
       sha256: "33b31b6beb98100bf9add464a36a8dd03eb10c7a8cf15aeec535e9b054aaf04b"
       url: "https://pub.dev"
     source: hosted
@@ -1424,7 +1380,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
-    version: "3.0.1"
   win32:
     dependency: transitive
     description:
@@ -1461,8 +1416,6 @@ packages:
     dependency: transitive
     description:
       name: yaml
-      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
-      url: "https://pub.dev"
       sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
       url: "https://pub.dev"
     source: hosted

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -607,6 +607,7 @@ class MockApiRepository extends _i1.Mock implements _i5.ApiRepository {
     String? search,
     String? ordering,
     bool? cancelled,
+    bool? queued,
   }) =>
           (super.noSuchMethod(
             Invocation.method(
@@ -619,6 +620,7 @@ class MockApiRepository extends _i1.Mock implements _i5.ApiRepository {
                 #search: search,
                 #ordering: ordering,
                 #cancelled: cancelled,
+                #queued: queued,
               },
             ),
             returnValue:
@@ -635,6 +637,7 @@ class MockApiRepository extends _i1.Mock implements _i5.ApiRepository {
                   #search: search,
                   #ordering: ordering,
                   #cancelled: cancelled,
+                  #queued: queued,
                 },
               ),
             )),


### PR DESCRIPTION
Closes #179.

### Summary
Added `queued` filter to API AdminEventRegistration request.
Added lists of `AdminEventRegistration`s `queuedRegistrations` and `cancelledRegistrations` to `EventAdminState` and `EventAdminCubit`.
Turned the `EventAdminScreen` into a screen with tabs, and gave queued and cancelled registrations their own type of tiles with useful info.

### How to test
Steps to test the changes you made:
1. Go to any event.
2. Click on the gear icon to go to admin view.

### Note about search
Search in its current form still only searches regular registrations.
I think this is OK as this is the most relevant use of search, and I want to avoid double work because of #427.