### PR TITLE
Disable Depandabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "pub"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    pull-request-branch-name:
-      separator: "-"
-    open-pull-requests-limit: 3


### PR DESCRIPTION
### Summary
Remove dependabot, its frequent updates were not really necessary, and it mostly caused mail spam.