### PR TITLE
Fix secondary color in the calendar

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/lib/ui/widgets/events.dart
+++ b/lib/ui/widgets/events.dart
@@ -270,7 +270,7 @@ class EventCard extends StatelessWidget {
     Color color;
     if (event.parentEvent is Event &&
         (event.parentEvent as Event).isRegistered) {
-      color = Theme.of(context).highlightColor;
+      color = Theme.of(context).colorScheme.primary;
     } else if (event.parentEvent is PartnerEvent) {
       color = Colors.black;
     } else {


### PR DESCRIPTION
### Summary
Somewhere along the release the secondary color used in the calendar got broken, maybe a flutter upgrade. This fixes that

### How to test
Steps to test the changes you made:
1. Go to calendar
2. Click on register for an event
3. Go back
4. See that it does not highlight registered events
