### PR TITLE
Fix crash oddity when moving events down

### DIFF
--- a/lib/ui/screens/calendar_screen.dart
+++ b/lib/ui/screens/calendar_screen.dart
@@ -263,13 +263,14 @@ class CalendarScrollView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final bool moveMonth = _monthGroupedEventsUp.isNotEmpty &&
+            _monthGroupedEventsDown.isEmpty &&
+            calendarState.isDoneDown;
     // If there are no future events we should still display some events
-    final upEvents = _monthGroupedEventsDown.isEmpty && calendarState.isDoneDown
+    final upEvents = moveMonth
         ? _monthGroupedEventsUp.skip(1).toList()
         : _monthGroupedEventsUp;
-    final downEvents = _monthGroupedEventsUp.isEmpty &&
-            _monthGroupedEventsDown.isEmpty &&
-            calendarState.isDoneDown
+    final downEvents = moveMonth
         ? [_monthGroupedEventsUp.first]
         : _monthGroupedEventsDown;
     ScrollPhysics scrollPhysics = const AlwaysScrollableScrollPhysics();

--- a/lib/ui/screens/calendar_screen.dart
+++ b/lib/ui/screens/calendar_screen.dart
@@ -264,15 +264,14 @@ class CalendarScrollView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bool moveMonth = _monthGroupedEventsUp.isNotEmpty &&
-            _monthGroupedEventsDown.isEmpty &&
-            calendarState.isDoneDown;
+        _monthGroupedEventsDown.isEmpty &&
+        calendarState.isDoneDown;
     // If there are no future events we should still display some events
     final upEvents = moveMonth
         ? _monthGroupedEventsUp.skip(1).toList()
         : _monthGroupedEventsUp;
-    final downEvents = moveMonth
-        ? [_monthGroupedEventsUp.first]
-        : _monthGroupedEventsDown;
+    final downEvents =
+        moveMonth ? [_monthGroupedEventsUp.first] : _monthGroupedEventsDown;
     ScrollPhysics scrollPhysics = const AlwaysScrollableScrollPhysics();
     return Column(
       children: [


### PR DESCRIPTION
Fixes an error that happens when there are no events in the future

### Summary
There used to be an inconsistency in removing events from up results past and adding them to the down results. This fixes that

### How to test
Steps to test the changes you made:
1. Go to calendar
2. Click on search
3. Search for something with no events (in the future)
4. See that either there are events, or the screen is black and you cannot scroll up
