### PR TITLE
Add a new abstract ListCubit that helps remove a lot of duplicate code

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,9 +5,6 @@ analyzer:
     # Do not analyze generated files.
     - lib/models/*.g.dart
     - lib/tosti/models/*.g.dart
-  
-  language:
-    strict-casts: false
 
 linter:
   rules:

--- a/lib/blocs/album_list_cubit.dart
+++ b/lib/blocs/album_list_cubit.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 
 import 'package:reaxit/api/api_repository.dart';
-import 'package:reaxit/api/exceptions.dart';
-import 'package:reaxit/config.dart';
 import 'package:reaxit/blocs/list_cubit.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';

--- a/lib/blocs/album_list_cubit.dart
+++ b/lib/blocs/album_list_cubit.dart
@@ -1,119 +1,37 @@
 import 'dart:async';
 
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/config.dart';
+import 'package:reaxit/blocs/list_cubit.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
 typedef AlbumListState = ListState<ListAlbum>;
 
-class AlbumListCubit extends Cubit<AlbumListState> {
-  static const int firstPageSize = 60;
-  static const int pageSize = 30;
+class AlbumListCubit extends SingleListCubit<ListAlbum> {
+  AlbumListCubit(ApiRepository api) : super(api);
 
-  final ApiRepository api;
+  static const int firstPageSize = 30;
 
-  /// The last used search query. Can be set through `this.search(query)`.
-  String? _searchQuery;
-
-  /// The last used search query. Can be set through `this.search(query)`.
-  String? get searchQuery => _searchQuery;
-
-  /// A timer used to debounce calls to `this.load()` from `this.search()`.
-  Timer? _searchDebounceTimer;
-
-  /// The offset to be used for the next paginated request.
-  int _nextOffset = 0;
-
-  AlbumListCubit(this.api) : super(const AlbumListState.loading(results: []));
-
-  Future<void> load() async {
-    emit(state.copyWith(isLoading: true));
-    try {
-      final query = _searchQuery;
-      final albumsResponse = await api.getAlbums(
-        search: query,
+  @override
+  Future<ListResponse<ListAlbum>> getDown(int offset) => api.getAlbums(
+        search: searchQuery,
         limit: firstPageSize,
-        offset: 0,
+        offset: offset,
       );
 
-      // Discard result if _searchQuery has
-      // changed since the request was made.
-      if (query != _searchQuery) return;
+  @override
+  List<ListAlbum> combineDown(
+          List<ListAlbum> downResults, ListState<ListAlbum> oldstate) =>
+      oldstate.results + downResults;
 
-      final isDone = albumsResponse.results.length == albumsResponse.count;
-
-      _nextOffset = firstPageSize;
-
-      if (albumsResponse.results.isEmpty) {
-        if (query?.isEmpty ?? true) {
-          emit(const AlbumListState.failure(message: 'There are no albums.'));
-        } else {
-          emit(AlbumListState.failure(
-            message: 'There are no albums found for "$query".',
-          ));
-        }
-      } else {
-        emit(AlbumListState.success(
-          results: albumsResponse.results,
-          isDone: isDone,
-        ));
-      }
-    } on ApiException catch (exception) {
-      emit(AlbumListState.failure(message: exception.message));
-    }
-  }
-
-  Future<void> more() async {
-    final oldState = state;
-
-    // Ignore calls to `more()` if there is no data, or already more coming.
-    if (oldState.isDone || oldState.isLoading || oldState.isLoadingMore) return;
-
-    emit(oldState.copyWith(isLoadingMore: true));
-    try {
-      final query = _searchQuery;
-
-      // Get next page of albums.
-      final albumsResponse = await api.getAlbums(
-        search: query,
-        limit: pageSize,
-        offset: _nextOffset,
-      );
-
-      // Discard result if _searchQuery has
-      // changed since the request was made.
-      if (query != _searchQuery) return;
-
-      final albums = state.results + albumsResponse.results;
-      final isDone = albums.length == albumsResponse.count;
-
-      _nextOffset += pageSize;
-
-      emit(AlbumListState.success(
-        results: albums,
-        isDone: isDone,
-      ));
-    } on ApiException catch (exception) {
-      emit(AlbumListState.failure(message: exception.message));
-    }
-  }
-
-  /// Set this cubit's `searchQuery` and load the albums for that query.
-  ///
-  /// Use `null` as argument to remove the search query.
-  void search(String? query) {
-    if (query != _searchQuery) {
-      _searchQuery = query;
-      _searchDebounceTimer?.cancel();
-      if (query?.isEmpty ?? false) {
-        /// Don't get results when the query is empty.
-        emit(const AlbumListState.loading(results: []));
-      } else {
-        _searchDebounceTimer = Timer(Config.searchDebounceTime, load);
-      }
+  @override
+  ListState<ListAlbum> empty(String query) {
+    if (query.isEmpty) {
+      return const ListState.failure(message: 'No albums found.');
+    } else {
+      return ListState.failure(message: 'No albums found for query $query.');
     }
   }
 }

--- a/lib/blocs/calendar_cubit.dart
+++ b/lib/blocs/calendar_cubit.dart
@@ -312,7 +312,7 @@ class CalendarCubit extends Cubit<CalendarState> {
       futureEvents.sort((a, b) => a.start.compareTo(b.start));
 
       if (!isDoneDown) {
-        // Filter events that we dont want to show just yet
+        // Filter events that we don't want to show just yet
         futureEvents = filterDown(futureEvents);
       }
 

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -35,7 +35,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
       upResponse = await upResultsFuture;
       downResponse = await downResultsFuture;
     } on ApiException catch (exception) {
-      emit(failure(exception.message));
+      _emit(failure(exception.message));
       return;
     }
 
@@ -59,9 +59,9 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     downResults = filterDown(downResults);
 
     if (upResults.isEmpty && downResults.isEmpty) {
-      emit(empty(query ?? ''));
+      _emit(empty(query ?? ''));
     } else {
-      emit(newState(
+      _emit(newState(
           resultsUp: upResults,
           resultsDown: downResults,
           isDoneUp: isDoneUp,
@@ -78,14 +78,14 @@ abstract class ListCubit<T, S> extends Cubit<S> {
       return;
     }
 
-    emit(loadingDown(oldState));
+    _emit(loadingDown(oldState));
 
     ListResponse<T> downResponse;
     try {
       Future<ListResponse<T>> downResultsFuture = getDown(_nextOffsetDown);
       downResponse = await downResultsFuture;
     } on ApiException catch (exception) {
-      emit(failure(exception.message));
+      _emit(failure(exception.message));
       return;
     }
 
@@ -101,7 +101,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
 
     final totalDownResults = combineDown(downResults, oldState);
 
-    emit(updateDown(oldState, totalDownResults, isDoneDown));
+    _emit(updateDown(oldState, totalDownResults, isDoneDown));
   }
 
   Future<void> moreUp() async {
@@ -113,14 +113,14 @@ abstract class ListCubit<T, S> extends Cubit<S> {
       return;
     }
 
-    emit(loadingUp(oldState));
+    _emit(loadingUp(oldState));
 
     ListResponse<T> upResponse;
     try {
       Future<ListResponse<T>> downResultsFuture = getUp(_nextOffsetUp);
       upResponse = await downResultsFuture;
     } on ApiException catch (exception) {
-      emit(failure(exception.message));
+      _emit(failure(exception.message));
       return;
     }
 
@@ -136,7 +136,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
 
     final totalUpResults = combineUp(downResults, oldState);
 
-    emit(updateUp(oldState, totalUpResults, isDoneUp));
+    _emit(updateUp(oldState, totalUpResults, isDoneUp));
   }
 
   /// Set this cubit's `searchQuery` and load the albums for that query.
@@ -148,11 +148,18 @@ abstract class ListCubit<T, S> extends Cubit<S> {
       _searchDebounceTimer?.cancel();
       if (query?.isEmpty ?? false) {
         /// Don't get results when the query is empty.
-        emit(loading());
+        _emit(empty(query ?? ''));
       } else {
         _searchDebounceTimer = Timer(Config.searchDebounceTime, load);
       }
     }
+  }
+
+  void _emit(S state) {
+    if (isClosed) {
+      return;
+    }
+    emit(state);
   }
 
   Future<ListResponse<T>> getUp(int offset);

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -7,7 +7,7 @@ import 'package:reaxit/config.dart' as config;
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
-abstract class ListCubit<T> extends Cubit<ListState<T>> {
+abstract class ListCubit<T, S> extends Cubit<S> {
   final ApiRepository api;
 
   /// The last used search query. Can be set through `this.search(query)`.
@@ -22,7 +22,6 @@ abstract class ListCubit<T> extends Cubit<ListState<T>> {
   int _nextOffsetUp = 0;
   int _nextOffsetDown = 0;
 
-  ListCubit(this.api) : super(const ListState.loading(results: []));
   /// A timer used to debounce calls to `this.load()` from `this.search()`.
   Timer? _searchDebounceTimer;
 
@@ -37,7 +36,7 @@ abstract class ListCubit<T> extends Cubit<ListState<T>> {
       upResponse = await upResultsFuture;
       downResponse = await downResultsFuture;
     } on ApiException catch (exception) {
-      emit(ListState.failure(message: exception.message));
+      emit(failure(exception.message));
       return;
     }
 
@@ -125,8 +124,14 @@ abstract class ListCubit<T> extends Cubit<ListState<T>> {
 
   // This is supposed to resolve some issues around the up/down boundry.
   // For example, when some results from up should be moved to down, this can be overwritten.
-  ({List<T> upResults, List<T> downResults}) shuffleData(List<T> upResults, List<T> downResults) => (upResults: upResults, downResults: downResults);
+  ({List<T> upResults, List<T> downResults}) shuffleData(
+          List<T> upResults, List<T> downResults) =>
+      (upResults: upResults, downResults: downResults);
 
-  List<T> filterUp(List<T> upResults);
-  List<T> filterDown(List<T> downResults);
+  List<T> filterUp(List<T> upResults) => upResults;
+  List<T> filterDown(List<T> downResults) => downResults;
+
+  S loading();
+  S failure(String message);
+
 }

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reaxit/api/api_repository.dart';
+import 'package:reaxit/api/exceptions.dart';
+import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/blocs.dart';
+import 'package:reaxit/models.dart';
+
+abstract class ListCubit<T> extends Cubit<ListState<T>> {
+  final ApiRepository api;
+
+  /// The last used search query. Can be set through `this.search(query)`.
+  String? _searchQuery;
+
+
+  // TODO: force implementors to set these somehow?
+  int firstPageSizeUp = 0;
+  int firstPageSizeDown = 0;
+
+  /// The offset to be used for the next paginated request.
+  int _nextOffsetUp = 0;
+  int _nextOffsetDown = 0;
+
+  ListCubit(this.api) : super(const ListState.loading(results: []));
+
+  Future<void> load() async {
+    final query = _searchQuery;
+    ListResponse<T> upResponse;
+    ListResponse<T> downResponse;
+    try{
+      Future<ListResponse<T>> upResultsFuture = getUp();
+      Future<ListResponse<T>> downResultsFuture = getDown();
+      cleanupOldState();
+      upResponse = await upResultsFuture;
+      downResponse = await downResultsFuture;
+    } on ApiException catch (exception) {
+      emit(ListState.failure(message: exception.message));
+      return;
+    }
+
+    // Discard result if _searchQuery has
+    // changed since the request was made.
+    if (query != _searchQuery) return;
+  
+    _nextOffsetUp = firstPageSizeUp;
+    _nextOffsetDown = firstPageSizeDown;
+
+    final isDoneDown =
+          upResponse.results.length == upResponse.count;
+    final isDoneUp =
+          downResponse.results.length == downResponse.count;
+
+    List<T> upResults = processUp(upResponse.results);
+    List<T> downResults = processUp(downResponse.results);
+
+    (upResults: upResults, downResults: downResults) = shuffleData(upResults, downResults);
+
+    upResults = filterUp(upResults);
+    downResults = filterDown(downResults);
+
+    // TODO: handle errors and emit results
+  }
+
+
+  Future<void> moreDown() async {
+    final oldState = state;
+    final query = _searchQuery;
+
+    // TODO: we need a 2 way ListState first
+    // Ignore calls to `more()` if there is no data, or already more coming.
+    // if (oldState.isDoneDown ||
+    //     oldState.isLoading ||
+    //     oldState.isLoadingMoreDown) {
+    //   return;
+    // }
+
+    ListResponse<T> downResponse;
+    try{
+      Future<ListResponse<T>> downResultsFuture = getUp();
+      downResponse = await downResultsFuture;
+    } on ApiException catch (exception) {
+      emit(ListState.failure(message: exception.message));
+      return;
+    }
+
+    // Discard result if _searchQuery has
+    // changed since the request was made.
+    if (query != _searchQuery) return;
+
+    final isDoneDown =
+          _nextOffsetDown + downResponse.results.length == downResponse.count;
+
+    List<T> upResults = processDown(downResponse.results);
+    upResults = filterDown(upResults);
+
+    final totalUpResults = oldState.results + upResults;
+
+    // TODO: emit results
+  }
+  
+  Future<ListResponse<T>> getUp();
+  Future<ListResponse<T>> getDown();
+
+  // This is called when a new load is triggered (after the API is called)
+  void cleanupOldState() => {};
+
+  List<T> processUp(List<T> upResults);
+  List<T> processDown(List<T> downResults);
+
+  // This is supposed to resolve some issues around the up/down boundry.
+  // For example, when some results from up should be moved to down, this can be overwritten.
+  ({List<T> upResults, List<T> downResults}) shuffleData(List<T> upResults, List<T> downResults) => (upResults: upResults, downResults: downResults);
+
+  List<T> filterUp(List<T> upResults);
+  List<T> filterDown(List<T> downResults);
+}

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
@@ -150,7 +150,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
         /// Don't get results when the query is empty.
         emit(loading());
       } else {
-        _searchDebounceTimer = Timer(config.searchDebounceTime, load);
+        _searchDebounceTimer = Timer(Config.searchDebounceTime, load);
       }
     }
   }

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -7,6 +7,10 @@ import 'package:reaxit/config.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
+// This is an abstract `Cubit`, which needs to be implemented by other classes.
+// If a class implements all the methods of `ListCubit`, it is a Cubit.
+// Since there are a lot of methods to implement, and most `ListCubit`s will be
+// one-way only, users should probably implement `SingleListCubit` instead.
 abstract class ListCubit<T, S> extends Cubit<S> {
   final ApiRepository api;
 
@@ -22,12 +26,15 @@ abstract class ListCubit<T, S> extends Cubit<S> {
 
   ListCubit(this.api, S state) : super(state);
 
+  // Initial load of the data, resets all the state and loads data in both ways.
+  // This follows a couple steps
   Future<void> load() async {
     final query = searchQuery;
     _nextOffsetUp = 0;
     _nextOffsetDown = 0;
     ListResponse<T> upResponse;
     ListResponse<T> downResponse;
+    // Get the data in both directions
     try {
       Future<ListResponse<T>> upResultsFuture = getUp(_nextOffsetUp);
       Future<ListResponse<T>> downResultsFuture = getDown(_nextOffsetDown);
@@ -49,12 +56,15 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     final isDoneUp = _nextOffsetUp == upResponse.count;
     final isDoneDown = _nextOffsetDown == downResponse.count;
 
+    // Do any processing that needs to be done on the data
     List<T> upResults = processUp(upResponse.results);
     List<T> downResults = processDown(downResponse.results);
 
+    // Allow the cubit to move data between up and down
     (upResults: upResults, downResults: downResults) =
         shuffleData(upResults, downResults);
 
+    // Some cubits need to filter out certain results
     upResults = filterUp(upResults);
     downResults = filterDown(downResults);
 
@@ -69,6 +79,9 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     }
   }
 
+  // moreDown loads more data in the down direction. For example when hitting
+  // the bottom when scrolling down. It follows the same prosedure as
+  // initial loading but only does half of it.
   Future<void> moreDown() async {
     final oldState = state;
     final query = searchQuery;
@@ -104,6 +117,9 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     _emit(updateDown(oldState, totalDownResults, isDoneDown));
   }
 
+  // moreUp loads more data in the up direction. For example when hitting
+  // the top when scrolling up. It follows the same prosedure as
+  // initial loading but only does half of it.
   Future<void> moreUp() async {
     final oldState = state;
     final query = searchQuery;
@@ -156,51 +172,91 @@ abstract class ListCubit<T, S> extends Cubit<S> {
   }
 
   void _emit(S state) {
+    // Since functions cannot be interupted in dart(without await), and isolates
+    // dont share memory. Thus we know there is no interuption between this check
+    // and emiting the state
     if (isClosed) {
       return;
     }
     emit(state);
   }
 
+  // getUp returns a future with more data in the up direction.
+  // This is where you would want to do an http request for example.
   Future<ListResponse<T>> getUp(int offset);
+  // getDown returns a future with more data in the down direction
+  // This is where you would want to do an http request for example.
   Future<ListResponse<T>> getDown(int offset);
 
   // This is called when a new load is triggered (after the API is called)
   void cleanupOldState() => {};
 
+  // processUp is called after getUp, and is used to process the data.
+  // For example, this can split daturned calendar events into multiple events.
   List<T> processUp(List<T> upResults) => upResults;
+  // processDown is called after getDown, and is used to process the data.
+  // For example, this can split daturned calendar events into multiple events.
   List<T> processDown(List<T> downResults) => downResults;
 
-  // This is supposed to resolve some issues around the up/down boundry.
-  // For example, when some results from up should be moved to down, this can be overwritten.
+  // This is supposed to resolve issues around the up/down boundry.
+  // For example, when some results from up should be moved to down,
+  // this can be overwritten.
   ({List<T> upResults, List<T> downResults}) shuffleData(
           List<T> upResults, List<T> downResults) =>
       (upResults: upResults, downResults: downResults);
 
+  // filterUp filters results in the up direction.
+  // This can be used to remove data that should not (yet) be shown to
+  // the user.
   List<T> filterUp(List<T> upResults) => upResults;
+  // filterDown filters results in the down direction.
+  // This can be used to remove data that should not (yet) be shown to
+  // the user.
   List<T> filterDown(List<T> downResults) => downResults;
 
+  // combineUp merges the new data with the new data, for the final result
   List<T> combineUp(List<T> upResults, S oldstate);
+  // combineDown merges the new data with the new data, for the final result
   List<T> combineDown(List<T> downResults, S oldstate);
 
+  // supressMoreUp is called to check if more data can/should be loaded
+  // (in loadMoreUp). For example when there is no more data, or we are
+  // already loading more data.
   bool supressMoreUp(S oldstate);
+  // supressMoreDown is called to check if more data can/should be loaded
+  // (in loadMoreDown). For example when there is no more data, or we are
+  // already loading more data.
   bool supressMoreDown(S oldstate);
 
+  // loading returns a state to be used when loading fully new data
   S loading();
+  // loadingUp returns a state to be used when loading new data in the up direction
   S loadingUp(S oldstate);
+  // loadingDown returns a state to be used when loading new data in the down direction
   S loadingDown(S oldstate);
+  // empty returns a state to be used when showing there is no data
   S empty(String query);
+  // failure returns a state to be used when showing there was a failure
   S failure(String message);
+  // newState returns a fully new state to be used in load
   S newState({
     List<T> resultsUp = const [],
     List<T> resultsDown = const [],
     required bool isDoneUp,
     required bool isDoneDown,
   });
+  // updateUp returns a state to be used when there is new data in the
+  // up direction
   S updateUp(S oldstate, List<T> upResults, bool isDoneUp);
+  // updateDown returns a state to be used when there is new data in the
+  // down direction
   S updateDown(S oldstate, List<T> downResults, bool isDoneDown);
 }
 
+// This class should be implemented when implementing a listcubit when only
+// needing to show data on one side (usually down). The methods you need to
+// overwrite are `getDown`, `combineDown`, and `empty`. This should makes it
+// trivial to implement a single ended ListCubit.
 abstract class SingleListCubit<T> extends ListCubit<T, ListState<T>> {
   SingleListCubit(ApiRepository api)
       : super(api, const ListState.loading(results: []));

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -192,5 +192,56 @@ abstract class ListCubit<T, S> extends Cubit<S> {
   });
   S updateUp(S oldstate, List<T> upResults, bool isDoneUp);
   S updateDown(S oldstate, List<T> downResults, bool isDoneDown);
+}
 
+abstract class SingleListCubit<T> extends ListCubit<T, ListState<T>> {
+  SingleListCubit(ApiRepository api)
+      : super(api, const ListState.loading(results: []));
+
+  @override
+  Future<ListResponse<T>> getUp(int offset) async => ListResponse<T>(0, []);
+
+  @override
+  List<T> combineUp(List<T> upResults, ListState oldstate) => upResults;
+
+  @override
+  bool supressMoreUp(ListState oldstate) => true;
+
+  @override
+  bool supressMoreDown(ListState oldstate) =>
+      oldstate.isDone || oldstate.isLoading || oldstate.isLoadingMore;
+
+  @override
+  ListState<T> loading() => const ListState.loading(results: []);
+
+  @override
+  ListState<T> loadingUp(ListState<T> oldstate) => oldstate;
+
+  @override
+  ListState<T> loadingDown(ListState<T> oldstate) =>
+      oldstate.copyWith(isLoadingMore: true);
+
+  @override
+  ListState<T> failure(String message) => ListState.failure(message: message);
+
+  @override
+  ListState<T> newState({
+    List<T> resultsUp = const [],
+    List<T> resultsDown = const [],
+    required bool isDoneUp,
+    required bool isDoneDown,
+  }) =>
+      ListState.success(results: resultsDown, isDone: isDoneDown);
+
+  @override
+  ListState<T> updateUp(
+          ListState<T> oldstate, List<T> upResults, bool isDoneUp) =>
+      oldstate;
+
+  @override
+  ListState<T> updateDown(
+          ListState<T> oldstate, List<T> downResults, bool isDoneDown) =>
+      oldstate.copyWith(results: downResults, isDone: isDoneDown);
+
+  Future<void> more() => moreDown();
 }

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -184,6 +184,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
   /// getUp returns a future with more data in the up direction.
   /// This is where you would want to do an http request for example.
   Future<ListResponse<T>> getUp(int offset);
+
   /// getDown returns a future with more data in the down direction
   /// This is where you would want to do an http request for example.
   Future<ListResponse<T>> getDown(int offset);
@@ -194,6 +195,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
   /// processUp is called after getUp, and is used to process the data.
   /// For example, this can split daturned calendar events into multiple events.
   List<T> processUp(List<T> upResults) => upResults;
+
   /// processDown is called after getDown, and is used to process the data.
   /// For example, this can split daturned calendar events into multiple events.
   List<T> processDown(List<T> downResults) => downResults;
@@ -209,6 +211,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
   /// This can be used to remove data that should not (yet) be shown to
   /// the user.
   List<T> filterUp(List<T> upResults) => upResults;
+
   /// filterDown filters results in the down direction.
   /// This can be used to remove data that should not (yet) be shown to
   /// the user.
@@ -216,6 +219,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
 
   /// combineUp merges the new data with the new data, for the final result
   List<T> combineUp(List<T> upResults, S oldstate);
+
   /// combineDown merges the new data with the new data, for the final result
   List<T> combineDown(List<T> downResults, S oldstate);
 
@@ -223,6 +227,7 @@ abstract class ListCubit<T, S> extends Cubit<S> {
   /// (in loadMoreUp). For example when there is no more data, or we are
   /// already loading more data.
   bool canLoadMoreDown(S oldstate);
+
   /// canLoadMoreUp is called to check if more data can/should be loaded
   /// (in loadMoreDown). For example when there is no more data, or we are
   /// already loading more data.
@@ -230,14 +235,19 @@ abstract class ListCubit<T, S> extends Cubit<S> {
 
   /// loading returns a state to be used when loading fully new data
   S loading();
+
   /// loadingUp returns a state to be used when loading new data in the up direction
   S loadingUp(S oldstate);
+
   /// loadingDown returns a state to be used when loading new data in the down direction
   S loadingDown(S oldstate);
+
   /// empty returns a state to be used when showing there is no data
   S empty(String query);
+
   /// failure returns a state to be used when showing there was a failure
   S failure(String message);
+
   /// newState returns a fully new state to be used in load
   S newState({
     List<T> resultsUp = const [],
@@ -245,9 +255,11 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     required bool isDoneUp,
     required bool isDoneDown,
   });
+
   /// updateUp returns a state to be used when there is new data in the
   /// up direction
   S updateUp(S oldstate, List<T> upResults, bool isDoneUp);
+
   /// updateDown returns a state to be used when there is new data in the
   /// down direction
   S updateDown(S oldstate, List<T> downResults, bool isDoneDown);

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -73,13 +73,12 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     final oldState = state;
     final query = searchQuery;
 
-    // TODO: we need a 2 way ListState first
     // Ignore calls to `more()` if there is no data, or already more coming.
-    // if (oldState.isDoneDown ||
-    //     oldState.isLoading ||
-    //     oldState.isLoadingMoreDown) {
-    //   return;
-    // }
+    if (supressMoreDown(oldState)) {
+      return;
+    }
+
+    emit(loadingDown(oldState));
 
     ListResponse<T> downResponse;
     try {
@@ -141,6 +140,9 @@ abstract class ListCubit<T, S> extends Cubit<S> {
 
   List<T> combineUp(List<T> upResults, S oldstate);
   List<T> combineDown(List<T> downResults, S oldstate);
+
+  bool supressMoreUp(S oldstate);
+  bool supressMoreDown(S oldstate);
 
   S loading();
   S loadingUp(S oldstate);

--- a/lib/blocs/list_cubit.dart
+++ b/lib/blocs/list_cubit.dart
@@ -7,27 +7,27 @@ import 'package:reaxit/config.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
-// This is an abstract `Cubit`, which needs to be implemented by other classes.
-// If a class implements all the methods of `ListCubit`, it is a Cubit.
-// Since there are a lot of methods to implement, and most `ListCubit`s will be
-// one-way only, users should probably implement `SingleListCubit` instead.
+/// This is an abstract `Cubit`, which needs to be implemented by other classes.
+/// If a class implements all the methods of `ListCubit`, it is a Cubit.
+/// Since there are a lot of methods to implement, and most `ListCubit`s will be
+/// one-way only, users should probably implement `SingleListCubit` instead.
 abstract class ListCubit<T, S> extends Cubit<S> {
   final ApiRepository api;
 
-  /// The last used search query. Can be set through `this.search(query)`.
+  //// The last used search query. Can be set through `this.search(query)`.
   String? searchQuery;
 
-  /// The offset to be used for the next paginated request.
+  //// The offset to be used for the next paginated request.
   int _nextOffsetUp = 0;
   int _nextOffsetDown = 0;
 
-  /// A timer used to debounce calls to `this.load()` from `this.search()`.
+  //// A timer used to debounce calls to `this.load()` from `this.search()`.
   Timer? _searchDebounceTimer;
 
   ListCubit(this.api, S state) : super(state);
 
-  // Initial load of the data, resets all the state and loads data in both ways.
-  // This follows a couple steps
+  /// Initial load of the data, resets all the state and loads data in both ways.
+  /// This follows a couple steps
   Future<void> load() async {
     final query = searchQuery;
     _nextOffsetUp = 0;
@@ -79,15 +79,15 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     }
   }
 
-  // moreDown loads more data in the down direction. For example when hitting
-  // the bottom when scrolling down. It follows the same prosedure as
-  // initial loading but only does half of it.
+  /// moreDown loads more data in the down direction. For example when hitting
+  /// the bottom when scrolling down. It follows the same prosedure as
+  /// initial loading but only does half of it.
   Future<void> moreDown() async {
     final oldState = state;
     final query = searchQuery;
 
     // Ignore calls to `more()` if there is no data, or already more coming.
-    if (supressMoreDown(oldState)) {
+    if (!canLoadMoreUp(oldState)) {
       return;
     }
 
@@ -117,15 +117,15 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     _emit(updateDown(oldState, totalDownResults, isDoneDown));
   }
 
-  // moreUp loads more data in the up direction. For example when hitting
-  // the top when scrolling up. It follows the same prosedure as
-  // initial loading but only does half of it.
+  /// moreUp loads more data in the up direction. For example when hitting
+  /// the top when scrolling up. It follows the same prosedure as
+  /// initial loading but only does half of it.
   Future<void> moreUp() async {
     final oldState = state;
     final query = searchQuery;
 
     // Ignore calls to `more()` if there is no data, or already more coming.
-    if (supressMoreUp(oldState)) {
+    if (!canLoadMoreDown(oldState)) {
       return;
     }
 
@@ -181,82 +181,82 @@ abstract class ListCubit<T, S> extends Cubit<S> {
     emit(state);
   }
 
-  // getUp returns a future with more data in the up direction.
-  // This is where you would want to do an http request for example.
+  /// getUp returns a future with more data in the up direction.
+  /// This is where you would want to do an http request for example.
   Future<ListResponse<T>> getUp(int offset);
-  // getDown returns a future with more data in the down direction
-  // This is where you would want to do an http request for example.
+  /// getDown returns a future with more data in the down direction
+  /// This is where you would want to do an http request for example.
   Future<ListResponse<T>> getDown(int offset);
 
-  // This is called when a new load is triggered (after the API is called)
+  /// This is called when a new load is triggered (after the API is called)
   void cleanupOldState() => {};
 
-  // processUp is called after getUp, and is used to process the data.
-  // For example, this can split daturned calendar events into multiple events.
+  /// processUp is called after getUp, and is used to process the data.
+  /// For example, this can split daturned calendar events into multiple events.
   List<T> processUp(List<T> upResults) => upResults;
-  // processDown is called after getDown, and is used to process the data.
-  // For example, this can split daturned calendar events into multiple events.
+  /// processDown is called after getDown, and is used to process the data.
+  /// For example, this can split daturned calendar events into multiple events.
   List<T> processDown(List<T> downResults) => downResults;
 
-  // This is supposed to resolve issues around the up/down boundry.
-  // For example, when some results from up should be moved to down,
-  // this can be overwritten.
+  /// This is supposed to resolve issues around the up/down boundry.
+  /// For example, when some results from up should be moved to down,
+  /// this can be overwritten.
   ({List<T> upResults, List<T> downResults}) shuffleData(
           List<T> upResults, List<T> downResults) =>
       (upResults: upResults, downResults: downResults);
 
-  // filterUp filters results in the up direction.
-  // This can be used to remove data that should not (yet) be shown to
-  // the user.
+  /// filterUp filters results in the up direction.
+  /// This can be used to remove data that should not (yet) be shown to
+  /// the user.
   List<T> filterUp(List<T> upResults) => upResults;
-  // filterDown filters results in the down direction.
-  // This can be used to remove data that should not (yet) be shown to
-  // the user.
+  /// filterDown filters results in the down direction.
+  /// This can be used to remove data that should not (yet) be shown to
+  /// the user.
   List<T> filterDown(List<T> downResults) => downResults;
 
-  // combineUp merges the new data with the new data, for the final result
+  /// combineUp merges the new data with the new data, for the final result
   List<T> combineUp(List<T> upResults, S oldstate);
-  // combineDown merges the new data with the new data, for the final result
+  /// combineDown merges the new data with the new data, for the final result
   List<T> combineDown(List<T> downResults, S oldstate);
 
-  // supressMoreUp is called to check if more data can/should be loaded
-  // (in loadMoreUp). For example when there is no more data, or we are
-  // already loading more data.
-  bool supressMoreUp(S oldstate);
-  // supressMoreDown is called to check if more data can/should be loaded
-  // (in loadMoreDown). For example when there is no more data, or we are
-  // already loading more data.
-  bool supressMoreDown(S oldstate);
+  /// canLoadMoreDown is called to check if more data can/should be loaded
+  /// (in loadMoreUp). For example when there is no more data, or we are
+  /// already loading more data.
+  bool canLoadMoreDown(S oldstate);
+  /// canLoadMoreUp is called to check if more data can/should be loaded
+  /// (in loadMoreDown). For example when there is no more data, or we are
+  /// already loading more data.
+  bool canLoadMoreUp(S oldstate);
 
-  // loading returns a state to be used when loading fully new data
+  /// loading returns a state to be used when loading fully new data
   S loading();
-  // loadingUp returns a state to be used when loading new data in the up direction
+  /// loadingUp returns a state to be used when loading new data in the up direction
   S loadingUp(S oldstate);
-  // loadingDown returns a state to be used when loading new data in the down direction
+  /// loadingDown returns a state to be used when loading new data in the down direction
   S loadingDown(S oldstate);
-  // empty returns a state to be used when showing there is no data
+  /// empty returns a state to be used when showing there is no data
   S empty(String query);
-  // failure returns a state to be used when showing there was a failure
+  /// failure returns a state to be used when showing there was a failure
   S failure(String message);
-  // newState returns a fully new state to be used in load
+  /// newState returns a fully new state to be used in load
   S newState({
     List<T> resultsUp = const [],
     List<T> resultsDown = const [],
     required bool isDoneUp,
     required bool isDoneDown,
   });
-  // updateUp returns a state to be used when there is new data in the
-  // up direction
+  /// updateUp returns a state to be used when there is new data in the
+  /// up direction
   S updateUp(S oldstate, List<T> upResults, bool isDoneUp);
-  // updateDown returns a state to be used when there is new data in the
-  // down direction
+  /// updateDown returns a state to be used when there is new data in the
+  /// down direction
   S updateDown(S oldstate, List<T> downResults, bool isDoneDown);
 }
 
-// This class should be implemented when implementing a listcubit when only
-// needing to show data on one side (usually down). The methods you need to
-// overwrite are `getDown`, `combineDown`, and `empty`. This should makes it
-// trivial to implement a single ended ListCubit.
+/// This class should be implemented when implementing a listcubit when only
+/// needing to show data on one side (usually down). The methods you need to
+/// overwrite are `getDown`, `combineDown`, and `empty`. This should makes it
+/// trivial to implement a single ended ListCubit.
 abstract class SingleListCubit<T> extends ListCubit<T, ListState<T>> {
   SingleListCubit(ApiRepository api)
       : super(api, const ListState.loading(results: []));
@@ -268,11 +268,11 @@ abstract class SingleListCubit<T> extends ListCubit<T, ListState<T>> {
   List<T> combineUp(List<T> upResults, ListState oldstate) => upResults;
 
   @override
-  bool supressMoreUp(ListState oldstate) => true;
+  bool canLoadMoreDown(ListState oldstate) => false;
 
   @override
-  bool supressMoreDown(ListState oldstate) =>
-      oldstate.isDone || oldstate.isLoading || oldstate.isLoadingMore;
+  bool canLoadMoreUp(ListState oldstate) =>
+      !oldstate.isDone && !oldstate.isLoading && !oldstate.isLoadingMore;
 
   @override
   ListState<T> loading() => const ListState.loading(results: []);


### PR DESCRIPTION
Closes #444.

### Summary
A lot of ListState cubits share a lot of code, and might behave in slightly different ways in some circumstances (like, is it cached, does it propperly do some checks). This PR introduces a class that unifies all common behavior but allows the necessary freedom.

### How to test
Steps to test the changes you made:
1. Visit all the pages that use a ListState