### PR TITLE
Enable picking between concrexit servers

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,7 +122,6 @@ jobs:
           MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
           MATCH_GIT_PRIVATE_KEY: ${{ secrets.PASSWORDS_REPO_DEPLOY_KEY }}
-          THALIA_API_HOST: ${{ vars.THALIA_API_HOST }}
           THALIA_OAUTH_APP_ID: ${{ secrets.THALIA_OAUTH_APP_ID }}
           THALIA_OAUTH_APP_SECRET: ${{ secrets.THALIA_OAUTH_APP_SECRET }}
           TOSTI_API_HOST: ${{ vars.TOSTI_API_HOST }}
@@ -198,7 +197,6 @@ jobs:
       - name: Build app
         env:
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
-          THALIA_API_HOST: ${{ vars.THALIA_API_HOST }}
           THALIA_OAUTH_APP_ID: ${{ secrets.THALIA_OAUTH_APP_ID }}
           THALIA_OAUTH_APP_SECRET: ${{ secrets.THALIA_OAUTH_APP_SECRET }}
           TOSTI_API_HOST: ${{ vars.TOSTI_API_HOST }}

--- a/fastlane/Fastfile-Android
+++ b/fastlane/Fastfile-Android
@@ -22,8 +22,7 @@ platform :android do
       build_cmd += " appbundle"
     end
 
-    if ENV["THALIA_OAUTH_APP_ID"] and ENV["THALIA_OAUTH_APP_SECRET"] and ENV["THALIA_API_HOST"]
-      build_cmd += " --dart-define=THALIA_API_HOST=\"#{ENV["THALIA_API_HOST"]}\""
+    if ENV["THALIA_OAUTH_APP_ID"] and ENV["THALIA_OAUTH_APP_SECRET"]
       build_cmd += " --dart-define=THALIA_OAUTH_APP_ID=\"#{ENV["THALIA_OAUTH_APP_ID"]}\""
       build_cmd += " --dart-define=THALIA_OAUTH_APP_SECRET=\"#{ENV["THALIA_OAUTH_APP_SECRET"]}\""
     end

--- a/fastlane/Fastfile-iOS
+++ b/fastlane/Fastfile-iOS
@@ -33,8 +33,7 @@ platform :ios do
     sh("flutter clean")
     build_cmd = "flutter build ios --release --config-only"
 
-    if ENV["THALIA_OAUTH_APP_ID"] and ENV["THALIA_OAUTH_APP_SECRET"] and ENV["THALIA_API_HOST"]
-      build_cmd += " --dart-define=THALIA_API_HOST=\"#{ENV["THALIA_API_HOST"]}\""
+    if ENV["THALIA_OAUTH_APP_ID"] and ENV["THALIA_OAUTH_APP_SECRET"]
       build_cmd += " --dart-define=THALIA_OAUTH_APP_ID=\"#{ENV["THALIA_OAUTH_APP_ID"]}\""
       build_cmd += " --dart-define=THALIA_OAUTH_APP_SECRET=\"#{ENV["THALIA_OAUTH_APP_SECRET"]}\""
     end

--- a/integration_test/login_screen_test.dart
+++ b/integration_test/login_screen_test.dart
@@ -21,7 +21,7 @@ void testLogin() {
             when(authCubit.state).thenReturn(state);
           })
           ..add(LoadingAuthState())
-          ..add(LoggedOutAuthState());
+          ..add(const LoggedOutAuthState());
 
         when(authCubit.load()).thenAnswer((_) => Future.value(null));
         when(authCubit.stream).thenAnswer((_) => streamController.stream);
@@ -138,7 +138,7 @@ void testLogin() {
 
         verify(authCubit.logOut()).called(1);
 
-        streamController.add(LoggedOutAuthState());
+        streamController.add(const LoggedOutAuthState());
         await tester.pumpAndSettle();
 
         expect(find.text('LOGIN'), findsOneWidget);

--- a/integration_test/login_screen_test.dart
+++ b/integration_test/login_screen_test.dart
@@ -138,7 +138,7 @@ void testLogin() {
 
         verify(authCubit.logOut()).called(1);
 
-        streamController.add(const LoggedOutAuthState());
+        streamController.add(LoggedOutAuthState(apiRepository: api));
         await tester.pumpAndSettle();
 
         expect(find.text('LOGIN'), findsOneWidget);

--- a/lib/api/api_repository.dart
+++ b/lib/api/api_repository.dart
@@ -1,3 +1,4 @@
+import 'package:reaxit/config.dart';
 import 'package:reaxit/models.dart';
 import 'package:reaxit/api/exceptions.dart';
 
@@ -7,7 +8,9 @@ import 'package:reaxit/api/exceptions.dart';
 /// In case credentials cannot be refreshed, this calls `logOut`, which should
 /// close the client and indicates that the user is no longer logged in.
 abstract class ApiRepository {
-  ApiRepository();
+  final Config config;
+
+  ApiRepository(this.config);
 
   /// Closes the connection to the api. This must be called when logging out.
   void close();

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -7,7 +7,7 @@ import 'package:http_parser/http_parser.dart';
 import 'package:oauth2/oauth2.dart' as oauth2;
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:reaxit/models.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -58,21 +58,25 @@ class ConcrexitApiRepository implements ApiRepository {
     /// The [oauth2.Client] used to access the API.
     required LoggingClient client,
 
+    /// An [ApiConfig] describing the API.
+    required ApiConfig config,
+
     /// Called when the client can no longer authenticate.
     required Function() onLogOut,
   })  : _client = client,
-        _onLogOut = onLogOut;
+        _onLogOut = onLogOut,
+        _baseUri = Uri(
+          scheme: config.scheme,
+          host: config.host,
+          port: config.port,
+        );
 
   @override
   void close() {
     _client.close();
   }
 
-  static final Uri _baseUri = Uri(
-    scheme: config.apiScheme,
-    host: config.apiHost,
-    port: config.apiPort,
-  );
+  final Uri _baseUri;
 
   static const String _basePath = 'api/v2';
 
@@ -82,7 +86,7 @@ class ConcrexitApiRepository implements ApiRepository {
   };
 
   /// Convenience method for building a URL to an API endpoint.
-  static Uri _uri({required String path, Map<String, dynamic>? query}) {
+  Uri _uri({required String path, Map<String, dynamic>? query}) {
     return _baseUri.replace(
       path: path.startsWith('/') ? '$_basePath$path' : '$_basePath/$path',
       queryParameters: query,

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -53,12 +53,13 @@ class ConcrexitApiRepository implements ApiRepository {
   @override
   final Config config;
 
-  /// The [oauth2.Client] used to access the API.
-  final LoggingClient _client;
+  /// The authenticated client used to access the API.
+  LoggingClient? _innerClient;
+
   final Function() _onLogOut;
 
   ConcrexitApiRepository({
-    /// The [oauth2.Client] used to access the API.
+    /// The authenticated client used to access the API.
     required LoggingClient client,
 
     /// An [Config] describing the API.
@@ -66,7 +67,7 @@ class ConcrexitApiRepository implements ApiRepository {
 
     /// Called when the client can no longer authenticate.
     required Function() onLogOut,
-  })  : _client = client,
+  })  : _innerClient = client,
         _onLogOut = onLogOut,
         _baseUri = Uri(
           scheme: config.scheme,
@@ -76,7 +77,21 @@ class ConcrexitApiRepository implements ApiRepository {
 
   @override
   void close() {
-    _client.close();
+    if (_innerClient != null) {
+      _innerClient!.close();
+      _innerClient = null;
+    }
+  }
+
+  /// The authenticated client used to access the API.
+  ///
+  /// Throws [ApiException.notLoggedIn] if the ApiRepository is not closed.
+  LoggingClient get _client {
+    if (_innerClient == null) {
+      throw ApiException.notLoggedIn;
+    } else {
+      return _innerClient!;
+    }
   }
 
   final Uri _baseUri;

--- a/lib/api/concrexit_api_repository.dart
+++ b/lib/api/concrexit_api_repository.dart
@@ -50,6 +50,9 @@ class LoggingClient extends oauth2.Client {
 /// In case credentials cannot be refreshed, this calls `logOut`, which should
 /// close the client and indicates that the user is no longer logged in.
 class ConcrexitApiRepository implements ApiRepository {
+  @override
+  final Config config;
+
   /// The [oauth2.Client] used to access the API.
   final LoggingClient _client;
   final Function() _onLogOut;
@@ -58,8 +61,8 @@ class ConcrexitApiRepository implements ApiRepository {
     /// The [oauth2.Client] used to access the API.
     required LoggingClient client,
 
-    /// An [ApiConfig] describing the API.
-    required ApiConfig config,
+    /// An [Config] describing the API.
+    required this.config,
 
     /// Called when the client can no longer authenticate.
     required Function() onLogOut,

--- a/lib/blocs/album_list_cubit.dart
+++ b/lib/blocs/album_list_cubit.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
@@ -112,7 +112,7 @@ class AlbumListCubit extends Cubit<AlbumListState> {
         /// Don't get results when the query is empty.
         emit(const AlbumListState.loading(results: []));
       } else {
-        _searchDebounceTimer = Timer(config.searchDebounceTime, load);
+        _searchDebounceTimer = Timer(Config.searchDebounceTime, load);
       }
     }
   }

--- a/lib/blocs/auth_cubit.dart
+++ b/lib/blocs/auth_cubit.dart
@@ -29,9 +29,8 @@ enum Environment {
   production,
   local;
 
-  static const defaultEnvironment = ApiConfig.production != null
-      ? Environment.production
-      : Environment.staging;
+  static const defaultEnvironment =
+      Config.production != null ? Environment.production : Environment.staging;
 }
 
 class AuthState extends Equatable {
@@ -113,15 +112,15 @@ class AuthCubit extends Cubit<AuthState> {
         // Restore credentials from the storage.
         final credentials = Credentials.fromJson(stored);
 
-        final ApiConfig apiConfig;
-        if (ApiConfig.production != null &&
-            credentials.tokenEndpoint == ApiConfig.production!.tokenEndpoint) {
-          apiConfig = ApiConfig.production!;
-        } else if (ApiConfig.local != null &&
-            credentials.tokenEndpoint == ApiConfig.local!.tokenEndpoint) {
-          apiConfig = ApiConfig.local!;
+        final Config apiConfig;
+        if (Config.production != null &&
+            credentials.tokenEndpoint == Config.production!.tokenEndpoint) {
+          apiConfig = Config.production!;
+        } else if (Config.local != null &&
+            credentials.tokenEndpoint == Config.local!.tokenEndpoint) {
+          apiConfig = Config.local!;
         } else {
-          apiConfig = ApiConfig.staging;
+          apiConfig = Config.staging;
         }
 
         // Log out if not all required scopes are available. After an update that
@@ -129,7 +128,7 @@ class AuthCubit extends Cubit<AuthState> {
         // credentials with the required scopes, instead of just getting 403's
         // until you manually log out.
         final scopes = credentials.scopes?.toSet() ?? <String>{};
-        if (scopes.containsAll(oauthScopes)) {
+        if (scopes.containsAll(Config.oauthScopes)) {
           // Create the API repository.
           final apiRepository = ConcrexitApiRepository(
             client: LoggingClient(
@@ -196,9 +195,9 @@ class AuthCubit extends Cubit<AuthState> {
     emit(LoadingAuthState());
 
     final apiConfig = switch (environment) {
-      Environment.staging => ApiConfig.staging,
-      Environment.production => ApiConfig.production ?? ApiConfig.staging,
-      Environment.local => ApiConfig.local ?? ApiConfig.staging,
+      Environment.staging => Config.staging,
+      Environment.production => Config.production ?? Config.staging,
+      Environment.local => Config.local ?? Config.staging,
     };
 
     // Prepare for the authentication flow.
@@ -222,7 +221,7 @@ class AuthCubit extends Cubit<AuthState> {
 
     final authorizeUrl = grant.getAuthorizationUrl(
       _redirectUrl,
-      scopes: oauthScopes,
+      scopes: Config.oauthScopes,
     );
 
     try {
@@ -304,7 +303,6 @@ class AuthCubit extends Cubit<AuthState> {
 
   /// Change the selected environment when on the login screen.
   void selectEnvironment(Environment environment) {
-    print(environment);
     final state = this.state;
     if (state is LoggedOutAuthState) {
       emit(LoggedOutAuthState(

--- a/lib/blocs/calendar_cubit.dart
+++ b/lib/blocs/calendar_cubit.dart
@@ -7,7 +7,7 @@ import 'package:intl/intl.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:reaxit/models.dart';
 
 /// Wrapper around a [BaseEvent] to be shown in the calendar.
@@ -505,7 +505,7 @@ class CalendarCubit extends Cubit<CalendarState> {
         emit(CalendarState(_truthTime,
             const DoubleListState.success(isDoneUp: true, isDoneDown: true)));
       } else {
-        _searchDebounceTimer = Timer(config.searchDebounceTime, load);
+        _searchDebounceTimer = Timer(Config.searchDebounceTime, load);
       }
     }
   }

--- a/lib/blocs/event_admin_cubit.dart
+++ b/lib/blocs/event_admin_cubit.dart
@@ -5,7 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:meta/meta.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:reaxit/models.dart';
 
 class EventAdminState extends Equatable {
@@ -183,7 +183,7 @@ class EventAdminCubit extends Cubit<EventAdminState> {
         ));
       } else {
         _searchDebounceTimer = Timer(
-          config.searchDebounceTime,
+          Config.searchDebounceTime,
           loadRegistrations,
         );
       }

--- a/lib/blocs/food_admin_cubit.dart
+++ b/lib/blocs/food_admin_cubit.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
@@ -66,7 +66,7 @@ class FoodAdminCubit extends Cubit<FoodAdminState> {
         /// Don't get results when the query is empty.
         emit(const LoadingState());
       } else {
-        _searchDebounceTimer = Timer(config.searchDebounceTime, load);
+        _searchDebounceTimer = Timer(Config.searchDebounceTime, load);
       }
     }
   }

--- a/lib/blocs/groups_cubit.dart
+++ b/lib/blocs/groups_cubit.dart
@@ -5,7 +5,7 @@ import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 
 typedef GroupsState = DetailState<List<ListGroup>>;
 
@@ -92,7 +92,7 @@ class AllGroupsCubit extends GroupsCubit {
         // Don't get results when the query is empty.
         emit(const LoadingState());
       } else {
-        _searchDebounceTimer = Timer(config.searchDebounceTime, load);
+        _searchDebounceTimer = Timer(Config.searchDebounceTime, load);
       }
     }
   }

--- a/lib/blocs/member_list_cubit.dart
+++ b/lib/blocs/member_list_cubit.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 
@@ -112,7 +112,7 @@ class MemberListCubit extends Cubit<MemberListState> {
         /// Don't get results when the query is empty.
         emit(const MemberListState.loading(results: []));
       } else {
-        _searchDebounceTimer = Timer(config.searchDebounceTime, load);
+        _searchDebounceTimer = Timer(Config.searchDebounceTime, load);
       }
     }
   }

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -106,3 +106,79 @@ const Duration cacheStalePeriod = Duration(days: 30);
 /// Assuming most cached images are 'small' (300x300), the
 /// storage used will be +- 20KB * [cacheMaxObjects].
 const int cacheMaxObjects = 2000;
+
+class ApiConfig {
+  final String host;
+  final String secret;
+  final String identifier;
+  final String scheme;
+  final int port;
+
+  const ApiConfig({
+    required this.host,
+    required this.secret,
+    required this.identifier,
+    required this.scheme,
+    required this.port,
+  });
+
+  String get cdn => 'cdn.$host';
+  Uri get authorizationEndpoint => Uri(
+        scheme: scheme,
+        host: host,
+        port: port,
+        path: 'user/oauth/authorize/',
+      );
+
+  Uri get tokenEndpoint => Uri(
+        scheme: scheme,
+        host: host,
+        port: port,
+        path: 'user/oauth/token/',
+      );
+
+  static const ApiConfig defaultConfig =
+      ApiConfig.production ?? ApiConfig.staging;
+
+  static const ApiConfig staging = ApiConfig(
+    host: 'staging.thalia.nu',
+    secret: 'Chwh1BE3MgfU1OZZmYRV3LU3e3GzpZJ6tiWrqzFY3dPhMlS7VYD3qMm1RC1pPBvg'
+        '3WaWmJxfRq8bv5ElVOpjRZwabAGOZ0DbuHhW3chAMaNlOmwXixNfUJIKIBzlnr7I',
+    identifier: '3zlt7pqGVMiUCGxOnKTZEpytDUN7haeFBP2kVkig',
+    scheme: 'https',
+    port: 443,
+  );
+
+  static const ApiConfig? production =
+      (bool.hasEnvironment('THALIA_OAUTH_APP_SECRET') &&
+              bool.hasEnvironment('THALIA_OAUTH_APP_ID'))
+          ? ApiConfig(
+              host: 'thalia.nu',
+              secret: String.fromEnvironment('THALIA_OAUTH_APP_SECRET'),
+              identifier: '3zlt7pqGVMiUCGxOnKTZEpytDUN7haeFBP2kVkig',
+              scheme: 'https',
+              port: 443,
+            )
+          : null;
+
+  static const ApiConfig? local =
+      (bool.hasEnvironment('LOCAL_THALIA_OAUTH_APP_SECRET') &&
+              bool.hasEnvironment('LOCAL_THALIA_OAUTH_APP_ID'))
+          ? ApiConfig(
+              host: String.fromEnvironment(
+                'LOCAL_THALIA_API_HOST',
+                defaultValue: '127.0.0.1',
+              ),
+              secret: String.fromEnvironment('LOCAL_THALIA_OAUTH_APP_SECRET'),
+              identifier: String.fromEnvironment('LOCAL_THALIA_OAUTH_APP_ID'),
+              scheme: String.fromEnvironment(
+                'LOCAL_THALIA_API_SCHEME',
+                defaultValue: 'http',
+              ),
+              port: int.fromEnvironment(
+                'LOCAL_THALIA_API_PORT',
+                defaultValue: 8000,
+              ),
+            )
+          : null;
+}

--- a/lib/config.dart
+++ b/lib/config.dart
@@ -1,35 +1,18 @@
+import 'package:flutter/widgets.dart';
+
 /// This file specifies configuration options that can be passed
 /// at compile time through `--dart-define`s, as is done by fastlane.
 ///
-/// The default values can be used on the staging server. If some variables are
-/// specified, be sure to specify all.
+/// By default, you can sign in to staging. If THALIA_OAUTH_APP_SECRET and
+/// THALIA_OAUTH_APP_ID are provided, you sign in to production by default.
+/// You can make it possible to sign in to a custom server by providing
+/// LOCAL_THALIA_OAUTH_APP_SECRET and LOCAL_THALIA_OAUTH_APP_ID, and optionally
+/// LOCAL_THALIA_API_HOST, LOCAL_THALIA_API_SCHEME and LOCAL_THALIA_API_PORT.
 ///
 /// If the `tostiXXX` variables are not defined, the T.O.S.T.I. API will not be
 /// used, and the corresponding UI will not be shown. This is because there is
 /// no staging T.O.S.T.I. server.
 /// The `tostiApiScheme` and `tostiApiPort` can be used for testing locally.
-const String apiHost = String.fromEnvironment(
-  'THALIA_API_HOST',
-  defaultValue: 'staging.thalia.nu',
-);
-
-const String apiHostCDN = 'cdn.$apiHost';
-
-const String apiSecret = String.fromEnvironment(
-  'THALIA_OAUTH_APP_SECRET',
-  defaultValue:
-      'Chwh1BE3MgfU1OZZmYRV3LU3e3GzpZJ6tiWrqzFY3dPhMlS7VYD3qMm1RC1pPBvg'
-      '3WaWmJxfRq8bv5ElVOpjRZwabAGOZ0DbuHhW3chAMaNlOmwXixNfUJIKIBzlnr7I',
-);
-
-const String apiIdentifier = String.fromEnvironment(
-  'THALIA_OAUTH_APP_ID',
-  defaultValue: '3zlt7pqGVMiUCGxOnKTZEpytDUN7haeFBP2kVkig',
-);
-
-const String apiScheme =
-    String.fromEnvironment('THALIA_API_SCHEME', defaultValue: 'https');
-const int apiPort = int.fromEnvironment('THALIA_API_PORT', defaultValue: 443);
 
 const String sentryDSN = String.fromEnvironment('SENTRY_DSN');
 
@@ -53,74 +36,29 @@ const List<String> tostiOauthScopes = [
   'thaliedje:manage',
 ];
 
-const List<String> oauthScopes = [
-  'read',
-  'write',
-  'activemembers:read',
-  'announcements:read',
-  'events:read',
-  'events:register',
-  'events:admin',
-  'food:read',
-  'food:order',
-  'food:admin',
-  'members:read',
-  'photos:read',
-  'profile:read',
-  'profile:write',
-  'pushnotifications:read',
-  'pushnotifications:write',
-  'payments:read',
-  'payments:write',
-  'payments:admin',
-  'partners:read',
-  'sales:read',
-  'sales:order',
-];
-
-const Duration searchDebounceTime = Duration(milliseconds: 200);
-
-const String versionNumber = 'v3.6.0';
-
-final Uri feedbackUri = Uri.parse(
-  'https://github.com/svthalia/Reaxit/issues',
-);
-
-final Uri changelogUri = Uri.parse(
-  'https://github.com/svthalia/Reaxit/releases',
-);
-
-final Uri termsAndConditionsUrl = Uri.parse(
-  'https://$apiHost/event-registration-terms/',
-);
-
-final Uri tpaySignDirectDebitMandateUrl = Uri.parse(
-  'https://$apiHost/user/finance/accounts/add/',
-);
-
-/// The period after which objects are removed from the cache when not used.
-const Duration cacheStalePeriod = Duration(days: 30);
-
-/// The maximum number of objects in the cache.
-///
-/// Assuming most cached images are 'small' (300x300), the
-/// storage used will be +- 20KB * [cacheMaxObjects].
-const int cacheMaxObjects = 2000;
-
-class ApiConfig {
+class Config {
   final String host;
   final String secret;
   final String identifier;
   final String scheme;
   final int port;
 
-  const ApiConfig({
+  const Config({
     required this.host,
     required this.secret,
     required this.identifier,
     required this.scheme,
     required this.port,
   });
+
+  /// The period after which objects are removed from the cache when not used.
+  static const Duration cacheStalePeriod = Duration(days: 30);
+
+  /// The maximum number of objects in the cache.
+  ///
+  /// Assuming most cached images are 'small' (300x300), the
+  /// storage used will be +- 20KB * [cacheMaxObjects].
+  static const int cacheMaxObjects = 2000;
 
   String get cdn => 'cdn.$host';
   Uri get authorizationEndpoint => Uri(
@@ -137,10 +75,54 @@ class ApiConfig {
         path: 'user/oauth/token/',
       );
 
-  static const ApiConfig defaultConfig =
-      ApiConfig.production ?? ApiConfig.staging;
+  static Uri feedbackUri = Uri.parse(
+    'https://github.com/svthalia/Reaxit/issues',
+  );
 
-  static const ApiConfig staging = ApiConfig(
+  static Uri changelogUri = Uri.parse(
+    'https://github.com/svthalia/Reaxit/releases',
+  );
+
+  Uri get termsAndConditionsUrl => Uri.parse(
+        'https://$host/event-registration-terms/',
+      );
+
+  Uri get tpaySignDirectDebitMandateUrl => Uri.parse(
+        'https://$host/user/finance/accounts/add/',
+      );
+
+  static const List<String> oauthScopes = [
+    'read',
+    'write',
+    'activemembers:read',
+    'announcements:read',
+    'events:read',
+    'events:register',
+    'events:admin',
+    'food:read',
+    'food:order',
+    'food:admin',
+    'members:read',
+    'photos:read',
+    'profile:read',
+    'profile:write',
+    'pushnotifications:read',
+    'pushnotifications:write',
+    'payments:read',
+    'payments:write',
+    'payments:admin',
+    'partners:read',
+    'sales:read',
+    'sales:order',
+  ];
+
+  static const Duration searchDebounceTime = Duration(milliseconds: 200);
+
+  static const String versionNumber = 'v3.6.0';
+
+  static const Config defaultConfig = Config.production ?? Config.staging;
+
+  static const Config staging = Config(
     host: 'staging.thalia.nu',
     secret: 'Chwh1BE3MgfU1OZZmYRV3LU3e3GzpZJ6tiWrqzFY3dPhMlS7VYD3qMm1RC1pPBvg'
         '3WaWmJxfRq8bv5ElVOpjRZwabAGOZ0DbuHhW3chAMaNlOmwXixNfUJIKIBzlnr7I',
@@ -149,22 +131,22 @@ class ApiConfig {
     port: 443,
   );
 
-  static const ApiConfig? production =
+  static const Config? production =
       (bool.hasEnvironment('THALIA_OAUTH_APP_SECRET') &&
               bool.hasEnvironment('THALIA_OAUTH_APP_ID'))
-          ? ApiConfig(
+          ? Config(
               host: 'thalia.nu',
               secret: String.fromEnvironment('THALIA_OAUTH_APP_SECRET'),
-              identifier: '3zlt7pqGVMiUCGxOnKTZEpytDUN7haeFBP2kVkig',
+              identifier: String.fromEnvironment('THALIA_OAUTH_APP_ID'),
               scheme: 'https',
               port: 443,
             )
           : null;
 
-  static const ApiConfig? local =
+  static const Config? local =
       (bool.hasEnvironment('LOCAL_THALIA_OAUTH_APP_SECRET') &&
               bool.hasEnvironment('LOCAL_THALIA_OAUTH_APP_ID'))
-          ? ApiConfig(
+          ? Config(
               host: String.fromEnvironment(
                 'LOCAL_THALIA_API_HOST',
                 defaultValue: '127.0.0.1',
@@ -181,4 +163,20 @@ class ApiConfig {
               ),
             )
           : null;
+
+  static Config of(BuildContext context) =>
+      context.dependOnInheritedWidgetOfExactType<InheritedConfig>()!.config;
+}
+
+class InheritedConfig extends InheritedWidget {
+  final Config config;
+
+  const InheritedConfig({
+    required this.config,
+    required Widget child,
+  }) : super(child: child);
+
+  @override
+  bool updateShouldNotify(covariant InheritedConfig oldWidget) =>
+      config != oldWidget.config;
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:overlay_support/overlay_support.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/blocs.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:reaxit/firebase_options.dart';
 import 'package:reaxit/routes.dart';
 import 'package:reaxit/tosti/blocs/auth_cubit.dart';
@@ -42,7 +42,7 @@ Future<void> main() async {
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
   await SentryFlutter.init(
     (options) {
-      options.dsn = config.sentryDSN;
+      options.dsn = sentryDSN;
     },
     appRunner: () async {
       runApp(BlocProvider(
@@ -290,65 +290,70 @@ class _ThaliAppState extends State<ThaliApp> {
                           (authState as LoggedOutAuthState).apiRepository!;
                     }
 
-                    return RepositoryProvider.value(
-                      value: apiRepository,
-                      child: MultiBlocProvider(
-                        providers: [
-                          BlocProvider(
-                            create: (_) =>
-                                PaymentUserCubit(apiRepository)..load(),
-                            lazy: false,
-                          ),
-                          BlocProvider(
-                            create: (_) =>
-                                FullMemberCubit(apiRepository)..load(),
-                            lazy: false,
-                          ),
-                          BlocProvider(
-                            create: (_) => WelcomeCubit(apiRepository)..load(),
-                            lazy: false,
-                          ),
-                          BlocProvider(
-                            create: (_) =>
-                                CalendarCubit(apiRepository)..cachedLoad(),
-                            lazy: false,
-                          ),
-                          BlocProvider(
-                            create: (_) =>
-                                MemberListCubit(apiRepository)..load(),
-                            lazy: false,
-                          ),
-                          BlocProvider(
-                            create: (_) =>
-                                AlbumListCubit(apiRepository)..load(),
-                            lazy: false,
-                          ),
-                          BlocProvider(
-                            // The SettingsCubit must not be lazy, since
-                            // it handles setting up push notifications.
-                            create: (_) => SettingsCubit(apiRepository)..load(),
-                            lazy: false,
-                          ),
-                          BlocProvider(
-                            create: (_) => TostiAuthCubit()..load(),
-                            lazy: true,
-                          ),
-                          BlocProvider(
-                            create: (_) => BoardsCubit(apiRepository)..load(),
-                            lazy: true,
-                          ),
-                          BlocProvider(
-                            create: (_) =>
-                                CommitteesCubit(apiRepository)..load(),
-                            lazy: true,
-                          ),
-                          BlocProvider(
-                            create: (_) =>
-                                SocietiesCubit(apiRepository)..load(),
-                            lazy: true,
-                          ),
-                        ],
-                        child: navigator!,
+                    return InheritedConfig(
+                      config: apiRepository.config,
+                      child: RepositoryProvider.value(
+                        value: apiRepository,
+                        child: MultiBlocProvider(
+                          providers: [
+                            BlocProvider(
+                              create: (_) =>
+                                  PaymentUserCubit(apiRepository)..load(),
+                              lazy: false,
+                            ),
+                            BlocProvider(
+                              create: (_) =>
+                                  FullMemberCubit(apiRepository)..load(),
+                              lazy: false,
+                            ),
+                            BlocProvider(
+                              create: (_) =>
+                                  WelcomeCubit(apiRepository)..load(),
+                              lazy: false,
+                            ),
+                            BlocProvider(
+                              create: (_) =>
+                                  CalendarCubit(apiRepository)..cachedLoad(),
+                              lazy: false,
+                            ),
+                            BlocProvider(
+                              create: (_) =>
+                                  MemberListCubit(apiRepository)..load(),
+                              lazy: false,
+                            ),
+                            BlocProvider(
+                              create: (_) =>
+                                  AlbumListCubit(apiRepository)..load(),
+                              lazy: false,
+                            ),
+                            BlocProvider(
+                              // The SettingsCubit must not be lazy, since
+                              // it handles setting up push notifications.
+                              create: (_) =>
+                                  SettingsCubit(apiRepository)..load(),
+                              lazy: false,
+                            ),
+                            BlocProvider(
+                              create: (_) => TostiAuthCubit()..load(),
+                              lazy: true,
+                            ),
+                            BlocProvider(
+                              create: (_) => BoardsCubit(apiRepository)..load(),
+                              lazy: true,
+                            ),
+                            BlocProvider(
+                              create: (_) =>
+                                  CommitteesCubit(apiRepository)..load(),
+                              lazy: true,
+                            ),
+                            BlocProvider(
+                              create: (_) =>
+                                  SocietiesCubit(apiRepository)..load(),
+                              lazy: true,
+                            ),
+                          ],
+                          child: navigator!,
+                        ),
                       ),
                     );
                   } else {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -203,10 +203,16 @@ class _ThaliAppState extends State<ThaliApp> {
       // logged in. If the user is logged in, and there is an original
       // path in the query parameters, redirect to that original path.
       redirect: (context, state) {
-        final loggedIn = _authCubit.state is LoggedInAuthState;
+        final authState = _authCubit.state;
+        final loggedIn = authState is LoggedInAuthState;
+        final justLoggedOut =
+            authState is LoggedOutAuthState && authState.apiRepository != null;
         final goingToLogin = state.location.startsWith('/login');
 
         if (!loggedIn && !goingToLogin) {
+          // Drop original location if you just logged out.
+          if (justLoggedOut) return '/login';
+
           return Uri(path: '/login', queryParameters: {
             'from': state.location,
           }).toString();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -278,7 +278,12 @@ class _ThaliAppState extends State<ThaliApp> {
                 },
                 buildWhen: (previous, current) => current is! FailureAuthState,
                 builder: (context, authState) {
-                  // Build with cubits provided when logged in.
+                  // Build with ApiRepository and cubits provided when an
+                  // ApiRepository is available. This is the case when logged
+                  // in, but also when just logged out (after having been logged
+                  // in), with a closed ApiRepository.
+                  // The latter allows us to keep the cubits alive
+                  // while animating towards the login screen.
                   if (authState is LoggedInAuthState ||
                       (authState is LoggedOutAuthState &&
                           authState.apiRepository != null)) {

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -1,6 +1,5 @@
 import 'package:json_annotation/json_annotation.dart';
 import 'package:reaxit/models.dart';
-import 'package:reaxit/config.dart' as config;
 
 part 'event.g.dart';
 
@@ -205,11 +204,6 @@ class AdminEvent implements BaseEvent {
 
   // final Uri markPresentUrl;
   final String markPresentUrlToken;
-  Uri get markPresentUrl => Uri(
-        scheme: 'https',
-        host: config.apiHost,
-        path: '/events/$pk/mark-present/$markPresentUrlToken',
-      );
 
   bool get registrationIsRequired =>
       registrationStart != null || registrationEnd != null;

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -11,14 +11,17 @@ import 'package:reaxit/ui/widgets.dart';
 
 /// Returns true if [uri] is a deep link that can be handled by the app.
 bool isDeepLink(Uri uri) {
-  if (uri.host != config.apiHost) return false;
-  return _deepLinkRegExps.any((re) => re.hasMatch(uri.path));
+  if (uri.host case 'thalia.nu' || 'staging.thalia.nu') {
+    return _deepLinkRegExps.any((re) => re.hasMatch(uri.path));
+  }
+  return false;
 }
 
 const _uuid = '([a-z0-9]{8}-([a-z0-9]{4}-){3}[a-z0-9]{12})';
 
-/* Any route added here also needs to be added to 
-android/app/src/main/AndroidManifest.xml and android/app/src/debug/AndroidManifest.xml */
+// Any route added here also needs to be added to
+// android/app/src/main/AndroidManifest.xml and
+// android/app/src/debug/AndroidManifest.xml
 
 /// The [RegExp]s that can used as deep links. This list should
 /// contain all deep links that should be handled by the app.

--- a/lib/ui/screens/album_screen.dart
+++ b/lib/ui/screens/album_screen.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/api/api_repository.dart';
+import 'package:reaxit/config.dart';
 import 'package:reaxit/models.dart';
 import 'package:reaxit/ui/widgets.dart';
-import 'package:reaxit/config.dart' as config;
 import 'package:reaxit/ui/widgets/gallery.dart';
 import 'package:reaxit/ui/widgets/photo_tile.dart';
 import 'package:share_plus/share_plus.dart';
@@ -35,8 +35,9 @@ class _AlbumScreenState extends State<AlbumScreen> {
   Future<void> _shareAlbum(BuildContext context) async {
     final messenger = ScaffoldMessenger.of(context);
     try {
+      final host = Config.of(context).host;
       await Share.share(
-        'https://${config.apiHost}/members/photos/${widget.slug}/',
+        'https://$host/members/photos/${widget.slug}/',
       );
     } catch (_) {
       messenger.showSnackBar(

--- a/lib/ui/screens/event_admin_screen.dart
+++ b/lib/ui/screens/event_admin_screen.dart
@@ -5,6 +5,7 @@ import 'package:qr_flutter/qr_flutter.dart';
 import 'package:reaxit/api/api_repository.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
+import 'package:reaxit/config.dart';
 import 'package:reaxit/models.dart';
 import 'package:reaxit/ui/widgets.dart';
 
@@ -129,6 +130,10 @@ class _MarkPresentQrButton extends StatelessWidget {
                 builder: (context, state) {
                   final theme = Theme.of(context);
                   if (state.event != null) {
+                    final host = Config.of(context).host;
+                    final pk = state.event!.pk;
+                    final token = state.event!.markPresentUrlToken;
+                    final url = 'https://$host/events/$pk/mark-present/$token';
                     return Column(
                       mainAxisSize: MainAxisSize.min,
                       children: [
@@ -140,7 +145,7 @@ class _MarkPresentQrButton extends StatelessWidget {
                           ),
                         ),
                         QrImage(
-                          data: state.event!.markPresentUrl.toString(),
+                          data: url,
                           padding: const EdgeInsets.all(24),
                           backgroundColor: Colors.grey[50]!,
                         ),

--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -14,7 +14,7 @@ import 'package:reaxit/ui/widgets.dart';
 import 'package:reaxit/ui/widgets/file_button.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 
 class EventScreen extends StatefulWidget {
   final String? slug;
@@ -761,7 +761,7 @@ class _EventScreenState extends State<EventScreen> {
   }
 
   TextSpan _makeTermsAndConditions(Event event) {
-    final url = config.termsAndConditionsUrl;
+    final url = Config.of(context).termsAndConditionsUrl;
     return TextSpan(
       children: [
         const TextSpan(

--- a/lib/ui/screens/login_screen.dart
+++ b/lib/ui/screens/login_screen.dart
@@ -124,7 +124,7 @@ class SelectEnvironmentDialog extends StatelessWidget {
             ),
             const SizedBox(height: 12),
             const Divider(height: 0),
-            if (ApiConfig.production != null)
+            if (Config.production != null)
               RadioListTile(
                 title: const Text('PRODUCTION'),
                 subtitle: const Text('Default: thalia.nu'),
@@ -149,7 +149,7 @@ class SelectEnvironmentDialog extends StatelessWidget {
                 );
               },
             ),
-            if (ApiConfig.local != null)
+            if (Config.local != null)
               RadioListTile(
                 title: const Text('LOCAL'),
                 subtitle: const Text('You should know what you are doing.'),

--- a/lib/ui/screens/login_screen.dart
+++ b/lib/ui/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/blocs.dart';
+import 'package:reaxit/config.dart';
 import 'package:reaxit/ui/theme.dart';
 
 class LoginScreen extends StatefulWidget {
@@ -23,23 +24,67 @@ class _LoginScreenState extends State<LoginScreen> {
   Widget build(BuildContext context) {
     return BlocBuilder<AuthCubit, AuthState>(
       buildWhen: (previous, current) =>
-          current is LoggedOutAuthState ||
-          current is LoadingAuthState ||
-          current is FailureAuthState,
+          current is LoggedOutAuthState || current is LoadingAuthState,
       builder: (context, authState) {
-        if (authState is LoadingAuthState) {
+        if (authState is LoggedOutAuthState) {
+          return Scaffold(
+            backgroundColor: magenta,
+            body: SafeArea(
+              child: Stack(
+                children: [
+                  Align(
+                    alignment: Alignment.topRight,
+                    child: IconButton(
+                      color: Colors.white54,
+                      padding: const EdgeInsets.all(16),
+                      icon: const Icon(Icons.build_rounded),
+                      tooltip:
+                          "Select environment, you probably don't need this",
+                      onPressed: () {
+                        showDialog(
+                          context: context,
+                          builder: (context) => const SelectEnvironmentDialog(),
+                        );
+                      },
+                    ),
+                  ),
+                  Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Center(child: Image(image: logo, width: 260)),
+                      const SizedBox(height: 50),
+                      SizedBox(
+                        height: 50,
+                        child: ElevatedButton(
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.black87,
+                            foregroundColor: Colors.white,
+                          ),
+                          onPressed: () {
+                            BlocProvider.of<AuthCubit>(context)
+                                .logIn(authState.selectedEnvironment);
+                          },
+                          child: Text(switch (authState.selectedEnvironment) {
+                            Environment.production => 'LOG IN',
+                            Environment.staging => 'LOG IN - STAGING',
+                            Environment.local => 'LOG IN - LOCAL',
+                          }),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          );
+        } else {
           return Scaffold(
             backgroundColor: const Color(0xFFE62272),
             body: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                Center(
-                  child: Image(
-                    image: logo,
-                    width: 260,
-                  ),
-                ),
+                Center(child: Image(image: logo, width: 260)),
                 const SizedBox(height: 50),
                 const SizedBox(
                   height: 50,
@@ -52,40 +97,81 @@ class _LoginScreenState extends State<LoginScreen> {
               ],
             ),
           );
-        } else {
-          return Scaffold(
-            backgroundColor: magenta,
-            body: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Center(
-                  child: Image(
-                    image: logo,
-                    width: 260,
-                  ),
-                ),
-                const SizedBox(height: 50),
-                SizedBox(
-                  height: 50,
-                  child: ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.black87,
-                      foregroundColor: Colors.white,
-                    ),
-                    onPressed: () {
-                      BlocProvider.of<AuthCubit>(
-                        context,
-                        listen: false,
-                      ).logIn();
-                    },
-                    child: const Text('LOGIN'),
-                  ),
-                ),
-              ],
-            ),
-          );
         }
       },
+    );
+  }
+}
+
+class SelectEnvironmentDialog extends StatelessWidget {
+  const SelectEnvironmentDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('SELECT ENVIRONMENT'),
+      content: BlocBuilder<AuthCubit, AuthState>(
+        buildWhen: (previous, current) => current is LoggedOutAuthState,
+        builder: (context, state) {
+          final selectedEnvironment = state is LoggedOutAuthState
+              ? state.selectedEnvironment
+              : Environment.defaultEnvironment;
+          return Column(mainAxisSize: MainAxisSize.min, children: [
+            Text(
+              'Select an alternative server to log in to. '
+              'If you are not sure you need this, just use production.',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 12),
+            const Divider(height: 0),
+            if (ApiConfig.production != null)
+              RadioListTile(
+                title: const Text('PRODUCTION'),
+                subtitle: const Text('Default: thalia.nu'),
+                value: Environment.production,
+                groupValue: selectedEnvironment,
+                onChanged: (environment) {
+                  BlocProvider.of<AuthCubit>(context).selectEnvironment(
+                    Environment.production,
+                  );
+                },
+              ),
+            RadioListTile(
+              title: const Text('STAGING'),
+              value: Environment.staging,
+              subtitle: const Text(
+                'Used by the Technicie for testing: staging.thalia.nu',
+              ),
+              groupValue: selectedEnvironment,
+              onChanged: (environment) {
+                BlocProvider.of<AuthCubit>(context).selectEnvironment(
+                  Environment.staging,
+                );
+              },
+            ),
+            if (ApiConfig.local != null)
+              RadioListTile(
+                title: const Text('LOCAL'),
+                subtitle: const Text('You should know what you are doing.'),
+                value: Environment.local,
+                groupValue: selectedEnvironment,
+                onChanged: (environment) {
+                  BlocProvider.of<AuthCubit>(context).selectEnvironment(
+                    Environment.local,
+                  );
+                },
+              ),
+          ]);
+        },
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+          child: const Text('CLOSE'),
+        )
+      ],
     );
   }
 }

--- a/lib/ui/screens/settings_screen.dart
+++ b/lib/ui/screens/settings_screen.dart
@@ -4,7 +4,7 @@ import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:reaxit/models.dart';
 import 'package:reaxit/ui/widgets.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class SettingsScreen extends StatelessWidget {
@@ -287,7 +287,7 @@ class _AboutCard extends StatelessWidget {
                           style: Theme.of(context).textTheme.headlineSmall,
                         ),
                         Text(
-                          config.versionNumber,
+                          Config.versionNumber,
                           style: Theme.of(context).textTheme.bodyMedium,
                         ),
                       ],
@@ -305,7 +305,7 @@ class _AboutCard extends StatelessWidget {
             OutlinedButton.icon(
               onPressed: () async {
                 await launchUrl(
-                  config.changelogUri,
+                  Config.changelogUri,
                   mode: LaunchMode.externalApplication,
                 );
               },
@@ -315,7 +315,7 @@ class _AboutCard extends StatelessWidget {
             OutlinedButton.icon(
               onPressed: () async {
                 await launchUrl(
-                  config.feedbackUri,
+                  Config.feedbackUri,
                   mode: LaunchMode.externalApplication,
                 );
               },
@@ -325,7 +325,7 @@ class _AboutCard extends StatelessWidget {
             OutlinedButton.icon(
               onPressed: () => showLicensePage(
                 context: context,
-                applicationVersion: config.versionNumber,
+                applicationVersion: Config.versionNumber,
                 applicationIcon: Builder(builder: (context) {
                   return Image.asset(
                     Theme.of(context).brightness == Brightness.light

--- a/lib/ui/widgets/tpay_button.dart
+++ b/lib/ui/widgets/tpay_button.dart
@@ -4,7 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:reaxit/config.dart';
 
 class TPayButton extends StatefulWidget {
   /// A function that performs the payment. If null, the button is disabled.
@@ -141,7 +141,7 @@ class _TPayButtonState extends State<TPayButton> {
             );
           } else if (!paymentUser.tpayEnabled) {
             // TPay not yet enabled.
-            final url = config.tpaySignDirectDebitMandateUrl;
+            final url = Config.of(context).tpaySignDirectDebitMandateUrl;
             final message = TextSpan(
               children: [
                 const TextSpan(

--- a/lib/utilities/cache_manager.dart
+++ b/lib/utilities/cache_manager.dart
@@ -1,17 +1,18 @@
-import 'package:flutter_cache_manager/flutter_cache_manager.dart';
-import 'package:reaxit/config.dart' as config;
+import 'package:flutter_cache_manager/flutter_cache_manager.dart' as cache;
+import 'package:reaxit/config.dart';
 
 /// A [BaseCacheManager] with customized configurations.
-class ThaliaCacheManager extends CacheManager with ImageCacheManager {
+class ThaliaCacheManager extends cache.CacheManager
+    with cache.ImageCacheManager {
   static const key = 'thaliaCachedData';
 
   static final ThaliaCacheManager _instance = ThaliaCacheManager._();
   factory ThaliaCacheManager() => _instance;
 
   ThaliaCacheManager._()
-      : super(Config(
+      : super(cache.Config(
           key,
-          stalePeriod: config.cacheStalePeriod,
-          maxNrOfCacheObjects: config.cacheMaxObjects,
+          stalePeriod: Config.cacheStalePeriod,
+          maxNrOfCacheObjects: Config.cacheMaxObjects,
         ));
 }

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -254,10 +254,10 @@ class MockAuthCubit extends _i1.Mock implements _i2.AuthCubit {
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
   @override
-  _i7.Future<void> logIn() => (super.noSuchMethod(
+  _i7.Future<void> logIn(_i2.Environment? environment) => (super.noSuchMethod(
         Invocation.method(
           #logIn,
-          [],
+          [environment],
         ),
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
@@ -271,6 +271,14 @@ class MockAuthCubit extends _i1.Mock implements _i2.AuthCubit {
         returnValue: _i7.Future<void>.value(),
         returnValueForMissingStub: _i7.Future<void>.value(),
       ) as _i7.Future<void>);
+  @override
+  void selectEnvironment(_i2.Environment? environment) => super.noSuchMethod(
+        Invocation.method(
+          #selectEnvironment,
+          [environment],
+        ),
+        returnValueForMissingStub: null,
+      );
   @override
   void emit(_i2.AuthState? state) => super.noSuchMethod(
         Invocation.method(

--- a/test/unit/routes_test.dart
+++ b/test/unit/routes_test.dart
@@ -1,11 +1,10 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaxit/routes.dart';
-import 'package:reaxit/config.dart' as config;
 
 void main() {
   group('isDeepLink', () {
     test('returns true if uri is a deep link', () {
-      const apiHost = config.apiHost;
+      const apiHost = 'thalia.nu';
       final validUris = [
         'https://$apiHost/events/1/',
         'https://$apiHost/events/1',
@@ -28,7 +27,7 @@ void main() {
     });
 
     test('returns false if uri is not a deep link', () {
-      const apiHost = config.apiHost;
+      const apiHost = 'thalia.nu';
       final invalidUris = [
         'https://$apiHost/contact',
         'https://example.org/events/1/',

--- a/test/widget/calendar_test.dart
+++ b/test/widget/calendar_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:reaxit/blocs.dart';
+import 'package:reaxit/config.dart';
 import 'package:reaxit/ui/screens.dart';
 
 import '../fakes.dart';
@@ -39,12 +40,15 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: CalendarScrollView(
-              controller: ScrollController(),
-              calendarState: state,
-              loadMoreUp: (() {}),
-              now: now,
+          home: InheritedConfig(
+            config: Config.defaultConfig,
+            child: Scaffold(
+              body: CalendarScrollView(
+                controller: ScrollController(),
+                calendarState: state,
+                loadMoreUp: (() {}),
+                now: now,
+              ),
             ),
           ),
         ),
@@ -77,12 +81,15 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: CalendarScrollView(
-              controller: ScrollController(),
-              calendarState: state,
-              loadMoreUp: (() {}),
-              now: now,
+          home: InheritedConfig(
+            config: Config.defaultConfig,
+            child: Scaffold(
+              body: CalendarScrollView(
+                controller: ScrollController(),
+                calendarState: state,
+                loadMoreUp: (() {}),
+                now: now,
+              ),
             ),
           ),
         ),

--- a/test/widget/tpay_button_test.dart
+++ b/test/widget/tpay_button_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:reaxit/api/exceptions.dart';
 import 'package:reaxit/blocs.dart';
+import 'package:reaxit/config.dart';
 import 'package:reaxit/models.dart';
 import 'package:reaxit/ui/widgets.dart';
 
@@ -30,15 +31,18 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: BlocProvider<PaymentUserCubit>.value(
-              value: paymentUserCubit,
-              child: TPayButton(
-                amount: '13.37',
-                successMessage: 'Nice!',
-                confirmationMessage: 'Are you sure?',
-                failureMessage: ':(',
-                onPay: () async => payCompleter.complete(),
+          home: InheritedConfig(
+            config: Config.defaultConfig,
+            child: Scaffold(
+              body: BlocProvider<PaymentUserCubit>.value(
+                value: paymentUserCubit,
+                child: TPayButton(
+                  amount: '13.37',
+                  successMessage: 'Nice!',
+                  confirmationMessage: 'Are you sure?',
+                  failureMessage: ':(',
+                  onPay: () async => payCompleter.complete(),
+                ),
               ),
             ),
           ),
@@ -80,15 +84,18 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: BlocProvider<PaymentUserCubit>.value(
-              value: paymentUserCubit,
-              child: TPayButton(
-                amount: '13.37',
-                successMessage: 'Nice!',
-                confirmationMessage: 'Are you sure?',
-                failureMessage: ':(',
-                onPay: () async => payCompleter.complete(),
+          home: InheritedConfig(
+            config: Config.defaultConfig,
+            child: Scaffold(
+              body: BlocProvider<PaymentUserCubit>.value(
+                value: paymentUserCubit,
+                child: TPayButton(
+                  amount: '13.37',
+                  successMessage: 'Nice!',
+                  confirmationMessage: 'Are you sure?',
+                  failureMessage: ':(',
+                  onPay: () async => payCompleter.complete(),
+                ),
               ),
             ),
           ),
@@ -127,17 +134,20 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: BlocProvider<PaymentUserCubit>.value(
-              value: paymentUserCubit,
-              child: TPayButton(
-                amount: '13.37',
-                successMessage: 'Nice!',
-                confirmationMessage: 'Are you sure?',
-                failureMessage: ':(',
-                onPay: () async {
-                  throw ApiException.unknownError;
-                },
+          home: InheritedConfig(
+            config: Config.defaultConfig,
+            child: Scaffold(
+              body: BlocProvider<PaymentUserCubit>.value(
+                value: paymentUserCubit,
+                child: TPayButton(
+                  amount: '13.37',
+                  successMessage: 'Nice!',
+                  confirmationMessage: 'Are you sure?',
+                  failureMessage: ':(',
+                  onPay: () async {
+                    throw ApiException.unknownError;
+                  },
+                ),
               ),
             ),
           ),
@@ -167,17 +177,20 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-            body: BlocProvider<PaymentUserCubit>.value(
-              value: paymentUserCubit,
-              child: TPayButton(
-                amount: '13.37',
-                successMessage: 'Nice!',
-                confirmationMessage: 'Are you sure?',
-                failureMessage: ':(',
-                onPay: () async {
-                  throw ApiException.unknownError;
-                },
+          home: InheritedConfig(
+            config: Config.defaultConfig,
+            child: Scaffold(
+              body: BlocProvider<PaymentUserCubit>.value(
+                value: paymentUserCubit,
+                child: TPayButton(
+                  amount: '13.37',
+                  successMessage: 'Nice!',
+                  confirmationMessage: 'Are you sure?',
+                  failureMessage: ':(',
+                  onPay: () async {
+                    throw ApiException.unknownError;
+                  },
+                ),
               ),
             ),
           ),

--- a/test/widget/welcome_test.dart
+++ b/test/widget/welcome_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:reaxit/blocs.dart';
+import 'package:reaxit/config.dart';
 import 'package:reaxit/models.dart';
 import 'package:reaxit/ui/screens.dart';
 
@@ -69,11 +70,14 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
-          home: Scaffold(
-              body: BlocProvider<WelcomeCubit>.value(
-            value: cubit,
-            child: WelcomeScreen(),
-          )),
+          home: InheritedConfig(
+            config: Config.defaultConfig,
+            child: Scaffold(
+                body: BlocProvider<WelcomeCubit>.value(
+              value: cubit,
+              child: WelcomeScreen(),
+            )),
+          ),
         ),
       );
 


### PR DESCRIPTION
Closes #457.

### Summary
This adds a button on the LoginScreen to pick an environment (production, staging or local) from options that depend on variables provided at build-time. That is, in development, only staging will be possible (and default). In CI builds, production will be added and defaulted to. And if you set `--dart-define=LOCAL_THALIA_OAUTH_APP_ID=XXX --dart-define=LOCAL_THALIA_OAUTH_APP_SECRET=XXX`, a local environment is also available (not picked by default), using `http://127.0.0.1:8000`.

I also got rid of a hack we used, removing the navigator around the LoginScreen.

TODO:
- [x] Handle it if closed ApiRepository is somehow still used.
- [x] Get the other urls from config dynamically.

### How to test
Steps to test the changes you made:
1. Make a production build
2. Sign in to production
3. Sign out
4. Sign in to staging
5. If you like, also try a build with local settings
