### PR TITLE
Update the food event to grey out when it is passed

### DIFF
--- a/lib/ui/screens/event_screen.dart
+++ b/lib/ui/screens/event_screen.dart
@@ -292,10 +292,12 @@ class _EventScreenState extends State<EventScreen> {
         Future.delayed(
           event.registrationStart!.difference(DateTime.now()),
           () {
-            setState(
-              () {},
-            );
-            _buttonControler.update(MaterialState.disabled, false);
+            if (mounted) {
+              _buttonControler.update(MaterialState.disabled, false);
+              setState(
+                () {},
+              );
+            }
           },
         );
       }

--- a/lib/ui/screens/food_screen.dart
+++ b/lib/ui/screens/food_screen.dart
@@ -53,10 +53,31 @@ class _FoodScreenState extends State<FoodScreen> {
 
     Text subtitle;
     if (!foodEvent.hasStarted()) {
+      Future.delayed(
+        foodEvent.start.difference(DateTime.now()),
+        () {
+          if (mounted) {
+            setState(
+              () {},
+            );
+          }
+        },
+      );
+
       subtitle = Text('It will be possible to order from $start.');
     } else if (foodEvent.hasEnded()) {
       subtitle = Text('It was possible to order until $end.');
     } else {
+      Future.delayed(
+        foodEvent.end.difference(DateTime.now()),
+        () {
+          if (mounted) {
+            setState(
+              () {},
+            );
+          }
+        },
+      );
       subtitle = Text('You can order until $end.');
     }
 


### PR DESCRIPTION
Closes #505 .

### Summary
When the food event ends, it is no longer possible to press the order button

### How to test
Steps to test the changes you made:
1. Go to a food order event
2. Wait for the event to end
