### PR TITLE
Fixed an issue with deeplinks

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -317,22 +317,6 @@ final List<RouteBase> routes = [
     ),
     routes: [
       GoRoute(
-          path: ':groupPk',
-          name: 'group',
-          pageBuilder: (context, state) => MaterialPage(
-              key: state.pageKey,
-              child: GroupScreen(
-                  pk: int.parse(state.pathParameters['groupPk']!),
-                  group: state.extra as ListGroup?))),
-      GoRoute(
-          path: ':groupPk',
-          name: 'board',
-          pageBuilder: (context, state) => MaterialPage(
-              key: state.pageKey,
-              child: GroupScreen(
-                  pk: int.parse(state.pathParameters['groupPk']!),
-                  group: state.extra as ListGroup?))),
-      GoRoute(
         path: 'committees',
         name: 'committees',
         pageBuilder: (context, state) => CustomTransitionPage(
@@ -419,6 +403,17 @@ final List<RouteBase> routes = [
             ),
           ),
         ],
+      ),
+      GoRoute(
+        path: ':groupPk',
+        name: 'group',
+        pageBuilder: (context, state) => MaterialPage(
+          key: state.pageKey,
+          child: GroupScreen(
+            pk: int.parse(state.pathParameters['groupPk']!),
+            group: state.extra as ListGroup?,
+          ),
+        ),
       ),
     ],
   ),


### PR DESCRIPTION
The deeplink /groups/{boards/...} would get interpreted as a group with pk {boards/...}. This would obviously not work and crash the app.

Closes #452.

### Summary
A clear and concise description of the changes that you made. 

### How to test
Steps to test the changes you made:
1. Go to a page of a group on the website
2. Open in app
3. Observe it not crashing
