### PR TITLE
Faster image scrolling and fix zoom out issue

### DIFF
--- a/lib/ui/widgets/cached_image.dart
+++ b/lib/ui/widgets/cached_image.dart
@@ -10,12 +10,14 @@ class CachedImage extends CachedNetworkImage {
     BoxFit super.fit = BoxFit.cover,
     Duration super.fadeOutDuration = const Duration(milliseconds: 200),
     super.fadeInDuration = const Duration(milliseconds: 200),
-    required String placeholder,
+    String? placeholder,
   }) : super(
           key: ValueKey(imageUrl),
           cacheManager: cache.ThaliaCacheManager(),
           cacheKey: _getCacheKey(imageUrl),
-          placeholder: (_, __) => Image.asset(placeholder, fit: fit),
+          placeholder: placeholder == null
+              ? null
+              : (_, __) => Image.asset(placeholder, fit: fit),
         );
 }
 

--- a/lib/ui/widgets/gallery.dart
+++ b/lib/ui/widgets/gallery.dart
@@ -12,6 +12,7 @@ import 'package:reaxit/models.dart';
 import 'package:reaxit/ui/theme.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:gal/gal.dart';
+import 'package:reaxit/ui/widgets/cached_image.dart';
 
 abstract class GalleryCubit<T> extends StateStreamableSource<T> {
   Future<void> updateLike({required bool liked, required int index});
@@ -169,9 +170,13 @@ class _GalleryState<C extends GalleryCubit> extends State<Gallery>
           child = GestureDetector(
             onDoubleTap: () => _likePhoto(photos, i),
             child: RotatedBox(
-              quarterTurns: photos[i].rotation ~/ 90,
-              child: Image.network(photos[i].full),
-            ),
+                quarterTurns: photos[i].rotation ~/ 90,
+                child: CachedImage(
+                  imageUrl: photos[i].full,
+                  fit: BoxFit.contain,
+                  // placeholder:
+                  //     'assets/img/photo_placeholder_${(360 - photos[i].rotation) % 360}.png'),
+                )),
           );
         } else {
           child = const Center(
@@ -181,7 +186,7 @@ class _GalleryState<C extends GalleryCubit> extends State<Gallery>
 
         return PhotoViewGalleryPageOptions.customChild(
           child: child,
-          minScale: PhotoViewComputedScale.contained * 0.8,
+          minScale: PhotoViewComputedScale.contained * 1,
           maxScale: PhotoViewComputedScale.covered * 2,
         );
       },

--- a/lib/ui/widgets/gallery.dart
+++ b/lib/ui/widgets/gallery.dart
@@ -174,8 +174,6 @@ class _GalleryState<C extends GalleryCubit> extends State<Gallery>
                 child: CachedImage(
                   imageUrl: photos[i].full,
                   fit: BoxFit.contain,
-                  // placeholder:
-                  //     'assets/img/photo_placeholder_${(360 - photos[i].rotation) % 360}.png'),
                 )),
           );
         } else {


### PR DESCRIPTION
Closes #458 

### Summary
Previously, you could zoom out on a photo in an album and it would stay zoomed out. 
Furthermore, photos are not cached correctly, so when you open a photo and scroll to the next one, the loading time is annoyingly long.

### How to test
Steps to test the changes you made:
1. Go to an album with a couple of photos so you can scroll a couple of times
2. Click on an image (I'd do the first one so you can scroll more)
3. Scroll a couple of times and the loading time will be a lot smaller. You can also zoom out and the photo will go back to the original size instead of a zoomed-out size.
