### PR TITLE
Ongoing events

### DIFF
--- a/lib/blocs/welcome_cubit.dart
+++ b/lib/blocs/welcome_cubit.dart
@@ -15,7 +15,7 @@ class WelcomeState extends Equatable {
   final List<FrontpageArticle>? articles;
 
   /// This can only be null when [isLoading] or [hasException] is true.
-  final List<BaseEvent>? upcomingEvents;
+  final List<BaseEvent>? events;
 
   /// This can only be null when [isLoading] or [hasException] is true.
   final List<Announcement>? announcements;
@@ -30,14 +30,14 @@ class WelcomeState extends Equatable {
   bool get hasResults =>
       slides != null &&
       articles != null &&
-      upcomingEvents != null &&
+      events != null &&
       announcements != null;
 
   @protected
   const WelcomeState({
     required this.slides,
     required this.articles,
-    required this.upcomingEvents,
+    required this.events,
     required this.announcements,
     required this.isLoading,
     required this.message,
@@ -47,7 +47,7 @@ class WelcomeState extends Equatable {
   List<Object?> get props => [
     slides,
     articles,
-    upcomingEvents,
+    events,
     announcements,
     message,
     isLoading,
@@ -56,14 +56,14 @@ class WelcomeState extends Equatable {
   WelcomeState copyWith({
     List<Slide>? slides,
     List<FrontpageArticle>? articles,
-    List<BaseEvent>? upcomingEvents,
+    List<BaseEvent>? events,
     List<Announcement>? announcements,
     bool? isLoading,
     String? message,
   }) => WelcomeState(
     slides: slides ?? this.slides,
     articles: articles ?? this.articles,
-    upcomingEvents: upcomingEvents ?? this.upcomingEvents,
+    events: events ?? this.events,
     announcements: announcements ?? this.announcements,
     isLoading: isLoading ?? this.isLoading,
     message: message ?? this.message,
@@ -72,7 +72,7 @@ class WelcomeState extends Equatable {
   const WelcomeState.result({
     required List<Slide> this.slides,
     required List<FrontpageArticle> this.articles,
-    required List<BaseEvent> this.upcomingEvents,
+    required List<BaseEvent> this.events,
     required List<Announcement> this.announcements,
   }) : message = null,
        isLoading = false;
@@ -80,7 +80,7 @@ class WelcomeState extends Equatable {
   const WelcomeState.loading({
     this.slides,
     this.articles,
-    this.upcomingEvents,
+    this.events,
     this.announcements,
   }) : message = null,
        isLoading = true;
@@ -88,7 +88,7 @@ class WelcomeState extends Equatable {
   const WelcomeState.failure({required String this.message})
     : slides = null,
       articles = null,
-      upcomingEvents = null,
+      events = null,
       announcements = null,
       isLoading = false;
 }
@@ -137,7 +137,7 @@ class WelcomeCubit extends Cubit<WelcomeState> {
         WelcomeState.result(
           slides: slides,
           articles: articlesResponse.results,
-          upcomingEvents: events,
+          events: events,
           announcements: announcementsResponse,
         ),
       );

--- a/lib/ui/screens/welcome_screen.dart
+++ b/lib/ui/screens/welcome_screen.dart
@@ -110,7 +110,14 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
   }
 
   Widget _makeUpcomingEvents(List<BaseEvent> events) {
-    final dayGroupedEvents = _groupByDay(events);
+    final now = DateTime.now();
+    List<BaseEvent> upcomingEvents =
+        events
+            .where(
+              (event) => !(event.start.isBefore(now) && event.end.isAfter(now)),
+            )
+            .toList();
+    final dayGroupedEvents = _groupByDay(upcomingEvents);
     return AnimatedSize(
       curve: Curves.ease,
       duration: const Duration(milliseconds: 300),

--- a/lib/ui/screens/welcome_screen.dart
+++ b/lib/ui/screens/welcome_screen.dart
@@ -109,6 +109,50 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
     );
   }
 
+  Widget _makeOngoingEvents(List<BaseEvent> events) {
+    final now = DateTime.now();
+    List<BaseEvent> ongoingEvents =
+        events
+            .where(
+              (event) => event.start.isBefore(now) && event.end.isAfter(now),
+            )
+            .toList();
+    final dayGroupedEvents = _groupByDay(ongoingEvents);
+    return AnimatedSize(
+      curve: Curves.ease,
+      duration: const Duration(milliseconds: 300),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+              'ONGOING EVENTS',
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 8),
+                for (final event in ongoingEvents)
+                  EventDetailCard(event: event),
+              ],
+            ),
+            if (dayGroupedEvents.isEmpty)
+              const Padding(
+                padding: EdgeInsets.all(8),
+                child: Text(
+                  'There are no ongoing events.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
   Widget _makeUpcomingEvents(List<BaseEvent> events) {
     final now = DateTime.now();
     List<BaseEvent> upcomingEvents =
@@ -201,6 +245,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
                     _makeArticles(state.articles!),
                     if (state.articles!.isNotEmpty)
                       const Divider(indent: 16, endIndent: 16, height: 8),
+                    _makeOngoingEvents(state.upcomingEvents!),
                     _makeUpcomingEvents(state.upcomingEvents!),
                     TextButton(
                       onPressed: () => context.goNamed('calendar'),

--- a/lib/ui/screens/welcome_screen.dart
+++ b/lib/ui/screens/welcome_screen.dart
@@ -155,7 +155,7 @@ class _WelcomeScreenState extends State<WelcomeScreen> {
               );
             }),
             if (events.isEmpty)
-              Padding(
+              const Padding(
                 padding: EdgeInsets.all(8),
                 child: Text(
                   'There are no upcoming events.',

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -16,6 +16,7 @@ import 'package:reaxit/config.dart' as _i3;
 import 'package:reaxit/models.dart' as _i4;
 import 'package:reaxit/models/announcement.dart' as _i12;
 import 'package:reaxit/models/thabliod.dart' as _i5;
+import 'package:reaxit/models/vacancie.dart' as _i13;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -1347,6 +1348,34 @@ class MockApiRepository extends _i1.Mock implements _i6.ApiRepository {
             ),
           )
           as _i9.Future<_i4.ListResponse<_i4.Payment>>);
+
+  @override
+  _i9.Future<_i4.ListResponse<_i13.Vacancy>> getVacancies({
+    int? limit,
+    int? offset,
+    DateTime? start,
+    DateTime? end,
+  }) =>
+      (super.noSuchMethod(
+            Invocation.method(#getVacancies, [], {
+              #limit: limit,
+              #offset: offset,
+              #start: start,
+              #end: end,
+            }),
+            returnValue: _i9.Future<_i4.ListResponse<_i13.Vacancy>>.value(
+              _FakeListResponse_3<_i13.Vacancy>(
+                this,
+                Invocation.method(#getVacancies, [], {
+                  #limit: limit,
+                  #offset: offset,
+                  #start: start,
+                  #end: end,
+                }),
+              ),
+            ),
+          )
+          as _i9.Future<_i4.ListResponse<_i13.Vacancy>>);
 }
 
 /// A class which mocks [PaymentUserCubit].


### PR DESCRIPTION
Closes #474 .

### Summary
Previously, ongoing events were displayed under the header upcoming events. This is not very nice so I added the header "ongoing events" which contains all ongoing events. If there are no ongoing events, the header will disappear. There are no ongoing events under the header upcoming events anymore. 

### How to test
1. Go to the welcome page in the app
2. All ongoing events should be under the header ongoing events. All upcoming events should be under the header upcoming events
